### PR TITLE
Bugfix/missing chain folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,8 @@ node_modules
 package-lock.json
 
 # ChainDB folder
-chaindb
+chaindb/*
+!chaindb/.placeholder
 
 # Build folder
 dist
-

--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,7 @@ node_modules
 package-lock.json
 
 # ChainDB folder
-chaindb/*
-!chaindb/.placeholder
+chaindb
 
 # Build folder
 dist

--- a/lib/chain/ChainManager.js
+++ b/lib/chain/ChainManager.js
@@ -53,7 +53,7 @@ class ChainManager {
     const initDir = path.isAbsolute(targetDir) ? sep : ''
     const baseDir = isRelativeToScript ? __dirname : '.'
 
-    targetDir.split(sep).reduce((parentDir, childDir) => {
+    path.normalize(targetDir).split(sep).reduce((parentDir, childDir) => {
       const curDir = path.resolve(baseDir, parentDir, childDir)
       try {
         fs.mkdirSync(curDir)


### PR DESCRIPTION
Fixes windows compatibility, explained in [issue 25 ](https://github.com/ethereumjs/ethereumjs-client/issues/25), basically the path division in win32 didn't work properly without normalizing it first.