### PR TITLE
Extend database and datadir tests

### DIFF
--- a/lib/chain/DBManager.js
+++ b/lib/chain/DBManager.js
@@ -28,11 +28,7 @@ class DBManager {
     targetDir.split(sep).reduce((parentDir, childDir) => {
       const curDir = path.resolve(baseDir, parentDir, childDir)
       if (!fs.existsSync(curDir)) {
-        try {
-          fs.mkdirSync(curDir)
-        } catch (err) {
-          throw err
-        }
+        fs.mkdirSync(curDir)
       }
       return curDir
     }, initDir)

--- a/tests/db-manager.js
+++ b/tests/db-manager.js
@@ -4,11 +4,24 @@ const tmp = require('tmp')
 const DBManager = require('../lib/chain/DBManager.js')
 const Logger = require('./mocks/Logger.js')
 
-tape('[DB]: Database functions', function (t) {
+tape('[DB]: Database functions', t => {
   const config = {}
   config.logger = Logger
 
-  t.test('should test data dir creation', function (st) {
+  t.test('should test object creation without logger', st => {
+    const config = {}
+    st.throws(() => new DBManager(config), /TypeError/)
+
+    st.end()
+  })
+
+  t.test('should test object creation without datadir', st => {
+    st.throws(() => new DBManager(config), /TypeError/)
+
+    st.end()
+  })
+
+  t.test('should test data dir creation', st => {
     const tmpdir = tmp.dirSync()
     config.datadir = `${tmpdir.name}/chaindb`
 
@@ -17,5 +30,42 @@ tape('[DB]: Database functions', function (t) {
     st.ok(fs.existsSync(config.datadir), 'data dir exists')
 
     st.end()
+  })
+
+  t.test('should test non-error on already created data dir', st => {
+    const tmpdir = tmp.dirSync()
+    config.datadir = `${tmpdir.name}/chaindb`
+
+    fs.mkdirSync(config.datadir)
+
+    st.ok(fs.existsSync(config.datadir), 'data dir exists before creating DBManager')
+
+    new DBManager(config) // eslint-disable-line no-new
+
+    st.ok(fs.existsSync(config.datadir), 'data dir exists after creating DBManager')
+
+    st.end()
+  })
+
+  t.test('should test blockchain DB is initialized', st => {
+    const tmpdir = tmp.dirSync()
+    config.datadir = `${tmpdir.name}/chaindb`
+
+    const dbm = new DBManager(config) // eslint-disable-line no-new
+
+    const db = dbm.blockchainDB()
+    const testKey = 'name'
+    const testValue = 'test'
+
+    db.put(testKey, testValue, function (err) {
+      if (err) st.fail('could not write key to db')
+
+      db.get(testKey, function (err, value) {
+        if (err) st.fail('could not read key to db')
+
+        st.equal(testValue, value, 'read value matches written value')
+        st.end()
+      })
+    })
   })
 })


### PR DESCRIPTION
Related to https://github.com/ethereumjs/ethereumjs-client/issues/21

Aims to close the first task `DB and directory initialization tests`. Extends existing DBManager tests, covering object and datadir creation and database availability after creation. 
