### PR TITLE
Remove unneeded test index file

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -1,1 +1,0 @@
-require('./db-manager.js')


### PR DESCRIPTION
With the changes in https://github.com/ethereumjs/ethereumjs-client/pull/30/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R10 an index file for tests is not needed anymore.