### PR TITLE
Run rpc server even if blockchain has not been synchronized

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,7 +34,7 @@ const args = require('yargs')
     'rpc': {
       describe: 'Enable the JSON-RPC server',
       boolean: true,
-      default: false
+      default: true
     },
     'rpcport': {
       describe: 'HTTP-RPC server listening port',
@@ -62,8 +62,7 @@ async function runNode (options) {
   logger.info(`Connecting to the ${options.network} network`)
   await node.open()
   logger.info('Synchronizing blockchain...')
-  await node.start()
-  logger.info('Synchronized')
+  node.start().then(() => logger.info('Synchronized'))
 
   return node
 }

--- a/lib/net/protocol/ethprotocol.js
+++ b/lib/net/protocol/ethprotocol.js
@@ -61,7 +61,7 @@ class EthProtocol extends Protocol {
    * @type {number[]}
    */
   get versions () {
-    return [62, 63]
+    return [63, 62]
   }
 
   /**


### PR DESCRIPTION
- Don't wait for chain to be synchronized before running the rpc server
- Enable RPC server by default