### PR TITLE
Header chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ to help contributors better understand how the project is organized.
 
 - ``/bin`` Contains the CLI script for the ``ethereumjs`` command
 - ``/docs`` Contains auto-generated API docs as well as other supporting documentation
-- ``/lib/blockchain`` Contains the ``Chain`` and ``BlockPool`` classes.
+- ``/lib/blockchain`` Contains the ``Chain``, ``BlockPool`` and ``HeaderPool`` classes.
 - ``/lib/net`` Contains all of the network layer classes including ``Peer``, ``Protocol`` and its subclasses,
   ``Server`` and its subclasses, and ``PeerPool``.
 - ``/lib/service`` Contains the various services. Currently, only ``EthService`` is implemented.
@@ -143,6 +143,8 @@ latest block.
 - ``BlockPool`` [**In Progress**] This class holds segments of the blockchain that have been downloaded
 from other peers. Once valid, sequential segments are available, they are automatically added to the
 blockchain
+    - ``HeaderPool`` [**In Progress**] This is a subclass of ``BlockPool`` that holds header segments instead of
+    block segments. It is useful for light syncs when downloading sequential headers in parallel.
 - ``Server`` This class represents a server that discovers new peers and handles incoming and dropped
 connections. When a new peer connects, the ``Server`` class will negotiate protocols and emit a ``connected``
 event with a new ``Peer``instance. The peer will have properties corresponding to each protocol. For example,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,7 +34,7 @@ const args = require('yargs')
     'rpc': {
       describe: 'Enable the JSON-RPC server',
       boolean: true,
-      default: true
+      default: false
     },
     'rpcport': {
       describe: 'HTTP-RPC server listening port',

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,7 +34,7 @@ const args = require('yargs')
     'rpc': {
       describe: 'Enable the JSON-RPC server',
       boolean: true,
-      default: false
+      default: true
     },
     'rpcport': {
       describe: 'HTTP-RPC server listening port',
@@ -62,8 +62,7 @@ async function runNode (options) {
   logger.info(`Connecting to the ${options.network} network`)
   await node.open()
   logger.info('Synchronizing blockchain...')
-  await node.start()
-  logger.info('Synchronized')
+  node.start().then(() => logger.info('Synchronized'))
 
   return node
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,19 +40,21 @@
         * [new Chain(options)](#new_module_blockchain.Chain_new)
         * [.networkId](#module_blockchain.Chain+networkId) : <code>number</code>
         * [.genesis](#module_blockchain.Chain+genesis) : <code>Object</code>
-        * [.td](#module_blockchain.Chain+td) : <code>BN</code>
-        * [.latest](#module_blockchain.Chain+latest) : <code>Block</code>
-        * [.height](#module_blockchain.Chain+height) : <code>BN</code>
+        * [.headers](#module_blockchain.Chain+headers) : <code>Object</code>
+        * [.blocks](#module_blockchain.Chain+blocks) : <code>Object</code>
         * [.db](#module_blockchain.Chain+db) : <code>Object</code>
         * [.open()](#module_blockchain.Chain+open) ⇒ <code>Promise</code>
         * [.close()](#module_blockchain.Chain+close) ⇒ <code>Promise</code>
         * [.update()](#module_blockchain.Chain+update) ⇒ <code>Promise</code>
-        * [.add()](#module_blockchain.Chain+add) ⇒ <code>Promise</code>
+        * [.add(blocks)](#module_blockchain.Chain+add) ⇒ <code>Promise</code>
+        * [.addHeaders(headers)](#module_blockchain.Chain+addHeaders) ⇒ <code>Promise</code>
+    * [.HeaderPool](#module_blockchain.HeaderPool)
+        * [.add(headers)](#module_blockchain.HeaderPool+add) ⇒ <code>Promise</code>
 
 <a name="module_blockchain.BlockPool"></a>
 
 ### blockchain.BlockPool
-Pool of blockchain segment
+Pool of blockchain segments
 
 **Kind**: static class of [<code>blockchain</code>](#module_blockchain)  
 
@@ -103,14 +105,14 @@ Blockchain
     * [new Chain(options)](#new_module_blockchain.Chain_new)
     * [.networkId](#module_blockchain.Chain+networkId) : <code>number</code>
     * [.genesis](#module_blockchain.Chain+genesis) : <code>Object</code>
-    * [.td](#module_blockchain.Chain+td) : <code>BN</code>
-    * [.latest](#module_blockchain.Chain+latest) : <code>Block</code>
-    * [.height](#module_blockchain.Chain+height) : <code>BN</code>
+    * [.headers](#module_blockchain.Chain+headers) : <code>Object</code>
+    * [.blocks](#module_blockchain.Chain+blocks) : <code>Object</code>
     * [.db](#module_blockchain.Chain+db) : <code>Object</code>
     * [.open()](#module_blockchain.Chain+open) ⇒ <code>Promise</code>
     * [.close()](#module_blockchain.Chain+close) ⇒ <code>Promise</code>
     * [.update()](#module_blockchain.Chain+update) ⇒ <code>Promise</code>
-    * [.add()](#module_blockchain.Chain+add) ⇒ <code>Promise</code>
+    * [.add(blocks)](#module_blockchain.Chain+add) ⇒ <code>Promise</code>
+    * [.addHeaders(headers)](#module_blockchain.Chain+addHeaders) ⇒ <code>Promise</code>
 
 <a name="new_module_blockchain.Chain_new"></a>
 
@@ -137,22 +139,20 @@ Network ID
 Genesis block parameters
 
 **Kind**: instance property of [<code>Chain</code>](#module_blockchain.Chain)  
-<a name="module_blockchain.Chain+td"></a>
+<a name="module_blockchain.Chain+headers"></a>
 
-#### chain.td : <code>BN</code>
-Total difficulty of canonical chain
-
-**Kind**: instance property of [<code>Chain</code>](#module_blockchain.Chain)  
-<a name="module_blockchain.Chain+latest"></a>
-
-#### chain.latest : <code>Block</code>
-Latest block in canonical chain
+#### chain.headers : <code>Object</code>
+Returns properties of the canonical headerchain. The ``latest`` property is
+the latest header in the chain, the ``td`` property is the total difficulty of
+headerchain, and the ``height`` is the height of the headerchain.
 
 **Kind**: instance property of [<code>Chain</code>](#module_blockchain.Chain)  
-<a name="module_blockchain.Chain+height"></a>
+<a name="module_blockchain.Chain+blocks"></a>
 
-#### chain.height : <code>BN</code>
-Blockchain height
+#### chain.blocks : <code>Object</code>
+Returns properties of the canonical blockchain. The ``latest`` property is
+the latest block in the chain, the ``td`` property is the total difficulty of
+blockchain, and the ``height`` is the height of the blockchain.
 
 **Kind**: instance property of [<code>Chain</code>](#module_blockchain.Chain)  
 <a name="module_blockchain.Chain+db"></a>
@@ -181,10 +181,45 @@ Update blockchain properties (latest block, td, height, etc...)
 **Kind**: instance method of [<code>Chain</code>](#module_blockchain.Chain)  
 <a name="module_blockchain.Chain+add"></a>
 
-#### chain.add() ⇒ <code>Promise</code>
+#### chain.add(blocks) ⇒ <code>Promise</code>
 Insert new blocks into blockchain
 
 **Kind**: instance method of [<code>Chain</code>](#module_blockchain.Chain)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| blocks | <code>Array.&lt;Block&gt;</code> \| <code>Block</code> | list of blocks or single block to add |
+
+<a name="module_blockchain.Chain+addHeaders"></a>
+
+#### chain.addHeaders(headers) ⇒ <code>Promise</code>
+Insert new headers into blockchain
+
+**Kind**: instance method of [<code>Chain</code>](#module_blockchain.Chain)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>Array.&lt;Header&gt;</code> | list of headers to add |
+
+<a name="module_blockchain.HeaderPool"></a>
+
+### blockchain.HeaderPool
+Pool of headerchain segments
+
+**Kind**: static class of [<code>blockchain</code>](#module_blockchain)  
+<a name="module_blockchain.HeaderPool+add"></a>
+
+#### headerPool.add(headers) ⇒ <code>Promise</code>
+Add a headerchain segment to the pool. Returns a promise that resolves once
+the segment has been added to the pool. Segments are automatically inserted
+into the blockchain once prior gaps are filled.
+
+**Kind**: instance method of [<code>HeaderPool</code>](#module_blockchain.HeaderPool)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>Array.&lt;Header&gt;</code> | list of sequential headers |
+
 <a name="module_net/peer"></a>
 
 ## net/peer
@@ -200,12 +235,12 @@ Insert new blocks into blockchain
         * [.server](#module_net/peer.Peer+server)
         * [.idle](#module_net/peer.Peer+idle) : <code>boolean</code>
         * [.idle](#module_net/peer.Peer+idle) : <code>boolean</code>
+        * [.bindProtocol(protocol, sender)](#module_net/peer.Peer+bindProtocol) ⇒ <code>Promise</code>
         * [.understands(protocolName)](#module_net/peer.Peer+understands)
     * [.RlpxPeer](#module_net/peer.RlpxPeer)
         * [new RlpxPeer(options)](#new_module_net/peer.RlpxPeer_new)
         * _instance_
             * [.connect()](#module_net/peer.RlpxPeer+connect) ⇒ <code>Promise</code>
-            * [.bindProtocols(rlpxPeer)](#module_net/peer.RlpxPeer+bindProtocols) ⇒ <code>Promise</code>
         * _static_
             * [.capabilities(protocols)](#module_net/peer.RlpxPeer.capabilities) ⇒ <code>Array.&lt;Object&gt;</code>
 
@@ -226,6 +261,7 @@ Network peer
     * [.server](#module_net/peer.Peer+server)
     * [.idle](#module_net/peer.Peer+idle) : <code>boolean</code>
     * [.idle](#module_net/peer.Peer+idle) : <code>boolean</code>
+    * [.bindProtocol(protocol, sender)](#module_net/peer.Peer+bindProtocol) ⇒ <code>Promise</code>
     * [.understands(protocolName)](#module_net/peer.Peer+understands)
 
 <a name="new_module_net/peer.Peer_new"></a>
@@ -316,6 +352,37 @@ Get idle state of peer
 Set idle state of peer
 
 **Kind**: instance property of [<code>Peer</code>](#module_net/peer.Peer)  
+<a name="module_net/peer.Peer+bindProtocol"></a>
+
+#### peer.bindProtocol(protocol, sender) ⇒ <code>Promise</code>
+Adds a protocol to this peer given a sender instance. Protocol methods
+will be accessible via a field with the same name as protocol. New methods
+will be added corresponding to each message defined by the protocol, in
+addition to send() and request() methods that takes a message name and message
+arguments. send() only sends a message without waiting for a response, whereas
+request() also sends the message but will return a promise that resolves with
+the response payload.
+
+**Kind**: instance method of [<code>Peer</code>](#module_net/peer.Peer)  
+**Access**: protected  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| protocol | <code>Protocol</code> | protocol instance |
+| sender | <code>Sender</code> | Sender instance provided by subclass |
+
+**Example**  
+```js
+await peer.bindProtocol(ethProtocol, sender)
+// Example: Directly call message name as a method on the bound protocol
+const headers1 = await peer.eth.getBlockHeaders(1, 100, 0, 0)
+// Example: Call request() method with message name as first parameter
+const headers2 = await peer.eth.request('getBlockHeaders', 1, 100, 0, 0)
+// Example: Call send() method with message name as first parameter and
+// wait for response message as an event
+peer.eth.send('getBlockHeaders', 1, 100, 0, 0)
+peer.eth.on('message', ({ data }) => console.log(`Received ${data.length} headers`))
+```
 <a name="module_net/peer.Peer+understands"></a>
 
 #### peer.understands(protocolName)
@@ -338,7 +405,6 @@ Devp2p/RLPx peer
     * [new RlpxPeer(options)](#new_module_net/peer.RlpxPeer_new)
     * _instance_
         * [.connect()](#module_net/peer.RlpxPeer+connect) ⇒ <code>Promise</code>
-        * [.bindProtocols(rlpxPeer)](#module_net/peer.RlpxPeer+bindProtocols) ⇒ <code>Promise</code>
     * _static_
         * [.capabilities(protocols)](#module_net/peer.RlpxPeer.capabilities) ⇒ <code>Array.&lt;Object&gt;</code>
 
@@ -382,21 +448,6 @@ new RlpxPeer({ id, host, port, protocols })
 Initiate peer connection
 
 **Kind**: instance method of [<code>RlpxPeer</code>](#module_net/peer.RlpxPeer)  
-<a name="module_net/peer.RlpxPeer+bindProtocols"></a>
-
-#### rlpxPeer.bindProtocols(rlpxPeer) ⇒ <code>Promise</code>
-Adds protocols to this peer given an rlpx native peer instance. Protocols
-will be accessible via a field with the same name as protocol. For each
-protocol, new methods will be added corresponding to each message defined
-by the protocol, in addition to a common send() method that takes a message
-name and message arguments.
-
-**Kind**: instance method of [<code>RlpxPeer</code>](#module_net/peer.RlpxPeer)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| rlpxPeer | <code>Object</code> | rlpx native peer |
-
 <a name="module_net/peer.RlpxPeer.capabilities"></a>
 
 #### RlpxPeer.capabilities(protocols) ⇒ <code>Array.&lt;Object&gt;</code>

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@
 
 <dl>
 <dt><a href="#BoundProtocol">BoundProtocol</a> ⇐ <code>EventEmitter</code></dt>
-<dd><p>Binds a protocl implementation to the specified peer</p>
+<dd><p>Binds a protocol implementation to the specified peer</p>
 </dd>
 </dl>
 
@@ -1410,7 +1410,7 @@ Base class for blockchain synchronizers
 <a name="BoundProtocol"></a>
 
 ## BoundProtocol ⇐ <code>EventEmitter</code>
-Binds a protocl implementation to the specified peer
+Binds a protocol implementation to the specified peer
 
 **Kind**: global class  
 **Extends**: <code>EventEmitter</code>  

--- a/lib/blockchain/blockpool.js
+++ b/lib/blockchain/blockpool.js
@@ -8,7 +8,7 @@ const defaultOptions = {
 }
 
 /**
- * Pool of blockchain segment
+ * Pool of blockchain segments
  * @memberof module:blockchain
  */
 class BlockPool {
@@ -59,7 +59,7 @@ class BlockPool {
       blocks = [ blocks ]
     }
 
-    let latest = this.chain.height
+    let latest = this.chain.blocks.height
     let first = new BN(blocks[0].header.number)
 
     if (first.gt(latest.addn(1))) {

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -9,6 +9,7 @@ const Block = require('ethereumjs-block')
 const Blockchain = require('ethereumjs-blockchain')
 const { BN } = require('ethereumjs-util')
 const { defaultLogger } = require('../logging')
+const { promisify } = require('util')
 
 const defaultOptions = {
   logger: defaultLogger,
@@ -46,9 +47,23 @@ class Chain extends EventEmitter {
       db: levelup(this.dataDir, { db: leveldown }),
       validate: false
     })
-    this._latest = {
-      block: null,
-      td: new BN(0)
+    // add promisified functions to blockchain instance for convenience
+    const bc = this.blockchain
+    bc.p = {
+      getLatestHeader: promisify(bc.getLatestHeader.bind(bc)),
+      getLatestBlock: promisify(bc.getLatestBlock.bind(bc)),
+      putBlocks: promisify(bc.putBlocks.bind(bc)),
+      getTd: promisify(bc._getTd.bind(bc))
+    }
+    this._headers = {
+      latest: null,
+      td: new BN(0),
+      height: new BN(0)
+    }
+    this._blocks = {
+      latest: null,
+      td: new BN(0),
+      height: new BN(0)
     }
     this.opened = false
   }
@@ -72,27 +87,23 @@ class Chain extends EventEmitter {
   }
 
   /**
-   * Total difficulty of canonical chain
-   * @type {BN}
+   * Returns properties of the canonical headerchain. The ``latest`` property is
+   * the latest header in the chain, the ``td`` property is the total difficulty of
+   * headerchain, and the ``height`` is the height of the headerchain.
+   * @type {Object}
    */
-  get td () {
-    return this._latest.td
+  get headers () {
+    return { ...this._headers }
   }
 
   /**
-   * Latest block in canonical chain
-   * @type {Block}
+   * Returns properties of the canonical blockchain. The ``latest`` property is
+   * the latest block in the chain, the ``td`` property is the total difficulty of
+   * blockchain, and the ``height`` is the height of the blockchain.
+   * @type {Object}
    */
-  get latest () {
-    return this._latest.block
-  }
-
-  /**
-   * Blockchain height
-   * @type {BN}
-   */
-  get height () {
-    return this.latest && new BN(this._latest.block.header.number)
+  get blocks () {
+    return { ...this._blocks }
   }
 
   /**
@@ -137,25 +148,26 @@ class Chain extends EventEmitter {
     if (!this.opened) {
       return false
     }
-    await new Promise((resolve, reject) => {
-      this.blockchain.getLatestBlock((err, block) => {
-        if (err) return reject(err)
-        this._latest.block = block
-        resolve()
-      })
-    })
-    await new Promise((resolve, reject) => {
-      this.blockchain._getTd(this._latest.block.hash(), (err, td) => {
-        if (err) return reject(err)
-        this._latest.td = td
-        resolve()
-      })
-    })
+    const headers = {}
+    const blocks = {}
+    await Promise.all([
+      this.blockchain.p.getLatestHeader(),
+      this.blockchain.p.getLatestBlock()
+    ]).then(latest => { [headers.latest, blocks.latest] = latest })
+    await Promise.all([
+      this.blockchain.p.getTd(headers.latest.hash()),
+      this.blockchain.p.getTd(blocks.latest.hash())
+    ]).then(td => { [headers.td, blocks.td] = td })
+    headers.height = new BN(headers.latest.number)
+    blocks.height = new BN(blocks.latest.header.number)
+    this._headers = headers
+    this._blocks = blocks
     this.emit('updated')
   }
 
   /**
    * Insert new blocks into blockchain
+   * @param  {Block[]|Block} blocks list of blocks or single block to add
    * @return {Promise}
    */
   async add (blocks) {
@@ -168,12 +180,21 @@ class Chain extends EventEmitter {
     if (!blocks || !blocks.length) {
       return false
     }
-
-    await new Promise((resolve, reject) => {
-      this.blockchain.putBlocks(blocks, err => err ? reject(err) : resolve())
-    })
-
+    await this.blockchain.p.putBlocks(blocks)
     await this.update()
+  }
+
+  /**
+   * Insert new headers into blockchain
+   * @param  {Header[]} headers list of headers to add
+   * @return {Promise}
+   */
+  async addHeaders (headers) {
+    if (!this.opened) {
+      return false
+    }
+    const blocks = headers.map(header => new Block([header.raw, [], []]))
+    await this.add(blocks)
   }
 }
 

--- a/lib/blockchain/headerpool.js
+++ b/lib/blockchain/headerpool.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const BlockPool = require('./blockpool')
+const BN = require('ethereumjs-util').BN
+
+/**
+ * Pool of headerchain segments
+ * @memberof module:blockchain
+ */
+class HeaderPool extends BlockPool {
+  /**
+   * Add a headerchain segment to the pool. Returns a promise that resolves once
+   * the segment has been added to the pool. Segments are automatically inserted
+   * into the blockchain once prior gaps are filled.
+   * @param {Header[]} headers list of sequential headers
+   * @return {Promise}
+   */
+  async add (headers) {
+    if (!this.opened) {
+      return false
+    }
+
+    if (!Array.isArray(headers)) {
+      headers = [ headers ]
+    }
+
+    let latest = this.chain.headers.height
+    let first = new BN(headers[0].number)
+
+    if (first.gt(latest.addn(1))) {
+      // if block segment arrived out of order, save it to the pool
+      this.pool.set(first.toString(), headers)
+      return
+    }
+    while (headers) {
+      // otherwise save headers and keep saving headers from header pool in order
+      let last = new BN(headers[headers.length - 1].number)
+      let hash = headers[0].hash().toString('hex').slice(0, 8) + '...'
+      await this.chain.addHeaders(headers)
+      this.logger.info(`Imported headers count=${headers.length} number=${first.toString(10)} hash=${hash}`)
+      latest = last
+      headers = this.pool.get(last.addn(1).toString())
+      if (headers) {
+        this.pool.delete(last.addn(1).toString())
+        first = new BN(headers[0].number)
+      }
+    }
+  }
+}
+
+module.exports = HeaderPool

--- a/lib/blockchain/index.js
+++ b/lib/blockchain/index.js
@@ -6,3 +6,4 @@
 
 exports.Chain = require('./chain')
 exports.BlockPool = require('./blockpool')
+exports.HeaderPool = require('./headerpool')

--- a/lib/net/peer/peer.js
+++ b/lib/net/peer/peer.js
@@ -88,7 +88,7 @@ class Peer extends EventEmitter {
    * arguments. send() only sends a message without waiting for a response, whereas
    * request() also sends the message but will return a promise that resolves with
    * the response payload.
-   * @private
+   * @protected
    * @param  {Protocol}  protocol protocol instance
    * @param  {Sender}    sender Sender instance provided by subclass
    * @return {Promise}

--- a/lib/net/peer/peer.js
+++ b/lib/net/peer/peer.js
@@ -84,11 +84,25 @@ class Peer extends EventEmitter {
    * Adds a protocol to this peer given a sender instance. Protocol methods
    * will be accessible via a field with the same name as protocol. New methods
    * will be added corresponding to each message defined by the protocol, in
-   * addition to a send() method that takes a message name and message arguments.
+   * addition to send() and request() methods that takes a message name and message
+   * arguments. send() only sends a message without waiting for a response, whereas
+   * request() also sends the message but will return a promise that resolves with
+   * the response payload.
    * @private
    * @param  {Protocol}  protocol protocol instance
    * @param  {Sender}    sender Sender instance provided by subclass
    * @return {Promise}
+   * @example
+   *
+   * await peer.bindProtocol(ethProtocol, sender)
+   * // Example: Directly call message name as a method on the bound protocol
+   * const headers1 = await peer.eth.getBlockHeaders(1, 100, 0, 0)
+   * // Example: Call request() method with message name as first parameter
+   * const headers2 = await peer.eth.request('getBlockHeaders', 1, 100, 0, 0)
+   * // Example: Call send() method with message name as first parameter and
+   * // wait for response message as an event
+   * peer.eth.send('getBlockHeaders', 1, 100, 0, 0)
+   * peer.eth.on('message', ({ data }) => console.log(`Received ${data.length} headers`))
    */
   async bindProtocol (protocol, sender) {
     const bound = await protocol.bind(this, sender)

--- a/lib/net/peer/rlpxpeer.js
+++ b/lib/net/peer/rlpxpeer.js
@@ -143,11 +143,8 @@ class RlpxPeer extends Peer {
   }
 
   /**
-   * Adds protocols to this peer given an rlpx native peer instance. Protocols
-   * will be accessible via a field with the same name as protocol. For each
-   * protocol, new methods will be added corresponding to each message defined
-   * by the protocol, in addition to a common send() method that takes a message
-   * name and message arguments.
+   * Adds protocols to this peer given an rlpx native peer instance.
+   * @private
    * @param  {Object}  rlpxPeer rlpx native peer
    * @return {Promise}
    */

--- a/lib/net/protocol/ethprotocol.js
+++ b/lib/net/protocol/ethprotocol.js
@@ -91,8 +91,8 @@ class EthProtocol extends Protocol {
   encodeStatus () {
     return {
       networkId: this.chain.networkId,
-      td: this.chain.td.toBuffer(),
-      bestHash: this.chain.latest.hash(),
+      td: this.chain.blocks.td.toBuffer(),
+      bestHash: this.chain.blocks.latest.hash(),
       genesisHash: this.chain.genesis.hash
     }
   }

--- a/lib/net/protocol/ethprotocol.js
+++ b/lib/net/protocol/ethprotocol.js
@@ -61,7 +61,7 @@ class EthProtocol extends Protocol {
    * @type {number[]}
    */
   get versions () {
-    return [62, 63]
+    return [63, 62]
   }
 
   /**

--- a/lib/net/protocol/protocol.js
+++ b/lib/net/protocol/protocol.js
@@ -9,7 +9,7 @@ const defaultOptions = {
 }
 
 /**
- * Binds a protocl implementation to the specified peer
+ * Binds a protocol implementation to the specified peer
  * @extends EventEmitter
  */
 class BoundProtocol extends EventEmitter {
@@ -72,9 +72,7 @@ class BoundProtocol extends EventEmitter {
     }
     const resolver = this.resolvers.get(incoming.code)
     if (resolver) {
-      if (resolver.timeout) {
-        clearTimeout(resolver.timeout)
-      }
+      clearTimeout(resolver.timeout)
       this.resolvers.delete(incoming.code)
       if (error) {
         resolver.reject(error)
@@ -85,7 +83,7 @@ class BoundProtocol extends EventEmitter {
       if (error) {
         this.emit('error', error)
       } else {
-        this.emit('message', message.name, data)
+        this.emit('message', { name: message.name, data: data })
       }
     }
   }

--- a/lib/sync/fastsync.js
+++ b/lib/sync/fastsync.js
@@ -2,8 +2,7 @@
 
 const Synchronizer = require('./sync')
 const Fetcher = require('./fetcher')
-const { BlockPool } = require('../blockchain')
-const Block = require('ethereumjs-block')
+const { HeaderPool } = require('../blockchain')
 const BN = require('ethereumjs-util').BN
 const { defaultLogger } = require('../logging')
 
@@ -67,7 +66,7 @@ class FastSynchronizer extends Synchronizer {
       }
       for (let peer of this.pool.peers) {
         const td = peer.eth.status.td
-        if ((!best && td.gt(this.chain.td)) ||
+        if ((!best && td.gt(this.chain.headers.td)) ||
             (best && best.eth.status.td.lt(td))) {
           best = peer
         }
@@ -97,19 +96,18 @@ class FastSynchronizer extends Synchronizer {
       pool: this.pool,
       logger: this.logger
     })
-    const blockPool = new BlockPool({
+    const headerPool = new HeaderPool({
       logger: this.logger,
       chain: this.chain
     })
 
-    await blockPool.open()
+    await headerPool.open()
     headerFetcher.on('headers', async (headers) => {
       if (!this.running) {
         return
       }
       try {
-        const blocks = headers.map(header => new Block([header.raw, [], []]))
-        await blockPool.add(blocks)
+        await headerPool.add(headers)
       } catch (error) {
         this.logger.error(`Header fetch error, trying again: ${error.stack}`)
         headerFetcher.add({
@@ -144,12 +142,12 @@ class FastSynchronizer extends Synchronizer {
     this.running = true
     await this.chain.open()
     await this.pool.open()
-    const number = this.chain.height.toString(10)
-    const td = this.chain.td.toString(10)
+    const number = this.chain.headers.height.toString(10)
+    const td = this.chain.headers.td.toString(10)
     this.logger.info(`Latest local header: number=${number} td=${td}`)
     const [ origin, height ] = await this.origin()
     this.logger.info(`Using origin peer: ${origin.toString(true)} height=${height.toString(10)}`)
-    await this.fetch(this.chain.height.addn(1), height)
+    await this.fetch(this.chain.headers.height.addn(1), height)
     this.running = false
   }
 

--- a/lib/sync/fetcher.js
+++ b/lib/sync/fetcher.js
@@ -37,6 +37,7 @@ class Fetcher extends EventEmitter {
     this.heap = new Heap({
       comparBefore: (a, b) => this.before(a, b)
     })
+    this.pool.on('removed', peer => this.failure(peer.id))
     this.running = false
   }
 
@@ -46,6 +47,41 @@ class Fetcher extends EventEmitter {
    */
   add (task) {
     this.heap.insert(task)
+  }
+
+  /**
+   * handle successful task completion
+   * @private
+   * @param  {string} peerId peer id
+   */
+  success (peerId) {
+    const entry = this.active.get(peerId)
+    if (entry) {
+      const { peer } = entry
+      peer.idle = true
+      this.active.delete(peer.id)
+      this.next()
+    }
+  }
+
+  /**
+   * handle failed task completion
+   * @private
+   * @param  {string} peerId peer id
+   * @param  {Error}  [error] error
+   */
+  failure (peerId, error) {
+    const entry = this.active.get(peerId)
+    if (entry) {
+      const { task, peer } = entry
+      peer.idle = true
+      this.active.delete(peerId)
+      this.add(task)
+      if (error) {
+        this.error(error, task, peer)
+      }
+      this.next()
+    }
   }
 
   /**
@@ -63,12 +99,7 @@ class Fetcher extends EventEmitter {
       this.active.set(peer.id, { time: Date.now(), task: task, peer: peer })
       this.fetch(task, peer)
         .then(data => this.handle(data, peer))
-        .catch(error => {
-          this.active.delete(peer.id)
-          this.add(task)
-          this.error(error, task, peer)
-          this.next()
-        })
+        .catch(error => this.failure(peer.id, error))
       return task
     } else {
       this.logger.debug(`No idle peers found. Waiting...`)
@@ -82,19 +113,18 @@ class Fetcher extends EventEmitter {
    * @param  {Peer}   peer
    */
   handle (data, peer) {
-    peer.idle = true
-    const { task } = this.active.get(peer.id)
-    if (task) {
-      this.active.delete(peer.id)
+    const entry = this.active.get(peer.id)
+    if (entry) {
+      const { task } = entry
       try {
         this.process(task, data)
+        this.success(peer.id)
       } catch (error) {
-        this.add(task)
-        this.error(error, task, peer)
+        this.failure(error)
       }
-      this.next()
     } else {
-      this.logger.warn(`Task missing for peer ${JSON.stringify(task)} ${peer}`)
+      peer.idle = true
+      this.logger.warn(`Task missing for peer ${peer}`)
     }
   }
 
@@ -144,7 +174,7 @@ class Fetcher extends EventEmitter {
         if (this.heap.length === 0 && this.active.size === 0) {
           this.running = false
         } else {
-          await timeout(this.maxFetchTime)
+          await timeout(1000)
         }
       }
     }

--- a/test/blockpool.js
+++ b/test/blockpool.js
@@ -30,9 +30,21 @@ tape('[BlockPool]: functions', t => {
     // add blocks out of order to make sure they are inserted in order
     await pool.add(block2)
     await pool.add(block1)
-    st.equal(chain.td.toString(16), '433333333', 'get chain.td')
-    st.equal(chain.height.toString(10), '2', 'get chain.height')
+    st.equal(chain.blocks.td.toString(16), '433333333', 'get chain.blocks.td')
+    st.equal(chain.blocks.height.toString(10), '2', 'get chain.blocks.height')
     chain.close()
+    st.end()
+  })
+
+  t.test('should check opened state', async (st) => {
+    const tmpdir = tmp.dirSync()
+    config.dataDir = `${tmpdir.name}/chaindb`
+
+    const chain = new Chain(config) // eslint-disable-line no-new
+    const pool = new BlockPool({ chain })
+    st.equal(await pool.add([]), false, 'not opened')
+    await pool.open()
+    st.equal(await pool.open(), false, 'already opened')
     st.end()
   })
 })

--- a/test/chain.js
+++ b/test/chain.js
@@ -74,14 +74,14 @@ tape('[Chain]: Database functions', t => {
     const chain = new Chain(config) // eslint-disable-line no-new
     await chain.open()
     st.equal(chain.networkId, 1, 'get chain.networkId')
-    st.equal(chain.td.toString(10), '17179869184', 'get chain.td')
-    st.equal(chain.height.toString(10), '0', 'get chain.height')
+    st.equal(chain.blocks.td.toString(10), '17179869184', 'get chain.blocks.td')
+    st.equal(chain.blocks.height.toString(10), '0', 'get chain.blocks.height')
     st.equal(chain.genesis.hash.toString('hex'),
       'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
       'get chain.genesis')
     st.equal(chain.genesis.hash.toString('hex'),
-      chain.latest.hash().toString('hex'),
-      'get chain.latest')
+      chain.blocks.latest.hash().toString('hex'),
+      'get chain.block.latest')
     chain.close()
     st.end()
   })
@@ -98,13 +98,14 @@ tape('[Chain]: Database functions', t => {
 
     st.equal(await chain.update(), false, 'skip update if not opened')
     st.equal(await chain.close(), false, 'skip close if not opened')
-    await chain.add(block)
-    st.notOk(chain.height, 'chain should be empty if not opened')
+    st.equal(await chain.add(block), false, 'skip add if not opened')
+    st.equal(await chain.addHeaders([block.header]), false, 'skip addHeaders if not opened')
+    st.notOk(chain.blocks.height.toNumber(), 'chain should be empty if not opened')
 
     await chain.open()
     st.equal(await chain.open(), false, 'skip open if already opened')
     await chain.add(block)
-    st.equal(chain.height.toString(10), '1', 'block should be added if chain opened')
+    st.equal(chain.blocks.height.toString(10), '1', 'block should be added if chain opened')
     st.end()
   })
 
@@ -132,8 +133,8 @@ tape('[Chain]: Database functions', t => {
     block.header.difficulty = '0xabcdffff'
     block.header.parentHash = chain.genesis.hash
     await chain.add(block)
-    st.equal(chain.td.toString(16), '4abcdffff', 'get chain.td')
-    st.equal(chain.height.toString(10), '1', 'get chain.height')
+    st.equal(chain.blocks.td.toString(16), '4abcdffff', 'get chain.td')
+    st.equal(chain.blocks.height.toString(10), '1', 'get chain.height')
     chain.close()
     st.end()
   })

--- a/test/headerpool.js
+++ b/test/headerpool.js
@@ -1,0 +1,48 @@
+const tape = require('tape')
+const tmp = require('tmp')
+const Block = require('ethereumjs-block')
+const util = require('ethereumjs-util')
+const { Chain, HeaderPool } = require('../lib/blockchain')
+const { defaultLogger } = require('../lib/logging')
+defaultLogger.silent = true
+
+tape('[HeaderPool]: functions', t => {
+  const config = {}
+
+  t.test('should add header segment to chain', async (st) => {
+    const tmpdir = tmp.dirSync()
+    config.dataDir = `${tmpdir.name}/chaindb`
+
+    const chain = new Chain(config) // eslint-disable-line no-new
+    const pool = new HeaderPool({ chain })
+    await pool.open()
+
+    const header1 = new Block.Header()
+    header1.number = util.toBuffer(1)
+    header1.difficulty = '0x11111111'
+    header1.parentHash = chain.genesis.hash
+
+    const header2 = new Block.Header()
+    header2.number = util.toBuffer(2)
+    header2.difficulty = '0x22222222'
+    header2.parentHash = header1.hash()
+
+    // add headers out of order to make sure they are inserted in order
+    await pool.add(header2)
+    await pool.add(header1)
+    st.equal(chain.headers.td.toString(16), '433333333', 'get chain.headers.td')
+    st.equal(chain.headers.height.toString(10), '2', 'get chain.headers.height')
+    chain.close()
+    st.end()
+  })
+
+  t.test('should check opened state', async (st) => {
+    const tmpdir = tmp.dirSync()
+    config.dataDir = `${tmpdir.name}/chaindb`
+
+    const chain = new Chain(config) // eslint-disable-line no-new
+    const pool = new HeaderPool({ chain })
+    st.equal(await pool.add([]), false, 'not opened')
+    st.end()
+  })
+})

--- a/test/logging.js
+++ b/test/logging.js
@@ -9,13 +9,19 @@ tape('[Logging]: Logging functions', t => {
       throw new Error('an error')
     } catch (e) {
       e.level = 'error'
-      t.ok(
+      st.ok(
         /an error\n {4}at/.test(logger.format.transform(e).message),
         'log message should contain stack trace (1)')
-      t.ok(
+      st.ok(
         /an error\n {4}at/.test(logger.format.transform({level: 'error', message: e}).message),
         'log message should contain stack trace (2)')
-      t.end()
+      st.end()
     }
+  })
+
+  t.test('should colorize key=value pairs', st => {
+    var { message } = logger.format.transform({level: 'info', message: 'test key=value'})
+    t.equal(message, 'test \u001b[32mkey\u001b[39m=value ', 'key=value pairs should be colorized')
+    st.end()
   })
 })


### PR DESCRIPTION
- Added new HeaderPool class
- Added support for header chains (needed for light sync)
- Cleaned up task fetcher
- Added more docs and an RlpxPeer example
- Fix bug with message events
- Don't wait for chain to be synchronized before running the rpc server

Once https://github.com/ethereumjs/ethereumjs-blockchain/pull/59 is merged, the header chain code can be greatly simplified