### PR TITLE
Fix error with geth genesis file parser

### DIFF
--- a/lib/util/parse.js
+++ b/lib/util/parse.js
@@ -3,7 +3,6 @@
 const Account = require('ethereumjs-account')
 const Block = require('ethereumjs-block')
 const Trie = require('merkle-patricia-tree/secure')
-const BN = require('ethereumjs-util').BN
 const url = require('url')
 const path = require('path')
 
@@ -43,9 +42,12 @@ async function parseGethState (alloc) {
   const trie = new Trie()
   const promises = []
   for (let [key, value] of Object.entries(alloc)) {
+    if (key.startsWith('0x')) {
+      key = key.slice(2)
+    }
     const address = Buffer.from(key, 'hex')
     const account = new Account()
-    account.balance = new BN(value.balance.slice(2), 16)
+    account.balance = value.balance
     promises.push(new Promise((resolve, reject) => {
       trie.put(address, account.serialize(), (err) => {
         if (err) return reject(err)


### PR DESCRIPTION
Fixes an issue where addresses with hex keys that don't begin with ``0x`` fail