### PR TITLE
Update ethereumjs-common to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ethereumjs-account": "^2.0.5",
     "ethereumjs-block": "^2.1.0",
     "ethereumjs-blockchain": "^3.3.1",
-    "ethereumjs-common": "^0.6.0",
+    "ethereumjs-common": "^0.6.1",
     "ethereumjs-devp2p": "^2.5.0",
     "ethereumjs-util": "^6.0.0",
     "fs-extra": "^6.0.1",


### PR DESCRIPTION
Add support for Goerli by upgrading ethereumjs-common to 0.6.1