### PR TITLE
Add eth_protocolVersion and modularize createNode in tests

### DIFF
--- a/lib/rpc/modules/eth.js
+++ b/lib/rpc/modules/eth.js
@@ -15,12 +15,16 @@ class Eth {
   constructor (node) {
     const service = node.services.find(s => s.name === 'eth')
     this._chain = service.chain
+    const ethProtocol = service.protocols.find(p => p.name === 'eth')
+    this.ethVersion = Math.max.apply(Math, ethProtocol.versions)
 
     this.getBlockByNumber = middleware(this.getBlockByNumber.bind(this), 2,
       [[validators.hex], [validators.bool]])
 
     this.getBlockByHash = middleware(this.getBlockByHash.bind(this), 2,
       [[validators.hex, validators.blockHash], [validators.bool]])
+
+    this.protocolVersion = middleware(this.protocolVersion.bind(this), 0, [])
   }
 
   /**
@@ -70,6 +74,16 @@ class Eth {
     } catch (err) {
       cb(err)
     }
+  }
+
+  /**
+   * Returns the current ethereum protocol version
+   * @param  {Array<>} [params] An empty array
+   * @param  {Function} [cb] A function with an error object as the first argument and a
+   * hex-encoded string of the current protocol version as the second argument
+   */
+  protocolVersion (params, cb) {
+    cb(null, `0x${this.ethVersion.toString(16)}`)
   }
 }
 

--- a/lib/service/ethereumservice.js
+++ b/lib/service/ethereumservice.js
@@ -30,7 +30,7 @@ class EthereumService extends Service {
    */
   constructor (options) {
     super(options)
-    options = { ...defaultOptions, ...options, ...{logger: this.logger} }
+    options = { ...defaultOptions, ...options, ...{ logger: this.logger } }
 
     this.syncmode = options.syncmode
     this.lightserv = options.lightserv
@@ -84,7 +84,7 @@ class EthereumService extends Service {
    * Returns all protocols required by this service
    * @type {Protocol[]} required protocols
    */
-  protocols () {
+  get protocols () {
     const protocols = []
     if (this.syncmode === 'light') {
       protocols.push(new LesProtocol({ chain: this.chain }))

--- a/lib/service/service.js
+++ b/lib/service/service.js
@@ -47,7 +47,7 @@ class Service extends EventEmitter {
    * Returns all protocols required by this service
    * @type {Protocol[]} required protocols
    */
-  protocols () {
+  get protocols () {
     return []
   }
 
@@ -59,7 +59,7 @@ class Service extends EventEmitter {
     if (this.opened) {
       return false
     }
-    const protocols = this.protocols()
+    const protocols = this.protocols
     this.servers.map(s => s.addProtocols(protocols))
     if (this.pool) {
       this.pool.on('banned', peer => this.logger.debug(`Peer banned: ${peer}`))

--- a/test/rpc/eth/getBlockByHash.js
+++ b/test/rpc/eth/getBlockByHash.js
@@ -1,29 +1,8 @@
 const test = require('tape')
 
 const request = require('supertest')
-const Common = require('ethereumjs-common')
 const { INVALID_PARAMS } = require('../../../lib/rpc/error-code')
-const { startRPC, closeRPC, createManager } = require('../helpers')
-const blockChain = require('../blockChainStub.js')
-const Chain = require('../../../lib/blockchain/chain.js')
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  let chain = new Chain({ blockchain: blockChain({}) })
-  chain.opened = true
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: chain,
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
-  }
-}
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 function checkError (expectedCode, expectedMessage) {
   return function (res) {

--- a/test/rpc/eth/getBlockByNumber.js
+++ b/test/rpc/eth/getBlockByNumber.js
@@ -1,9 +1,8 @@
 const test = require('tape')
 
 const request = require('supertest')
-const Common = require('ethereumjs-common')
 const { INVALID_PARAMS } = require('../../../lib/rpc/error-code')
-const { startRPC, closeRPC, createManager } = require('../helpers')
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 function createBlockchain () {
   const transactions = [
@@ -16,22 +15,6 @@ function createBlockchain () {
   }
   return {
     getBlock: () => block
-  }
-}
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: createBlockchain(),
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
   }
 }
 
@@ -50,7 +33,7 @@ function checkError (expectedCode, expectedMessage) {
 }
 
 test('call eth_getBlockByNumber with valid arguments', t => {
-  const manager = createManager(createNode())
+  const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -77,7 +60,7 @@ test('call eth_getBlockByNumber with valid arguments', t => {
 })
 
 test('call eth_getBlockByNumber with false for second argument', t => {
-  const manager = createManager(createNode())
+  const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -107,7 +90,7 @@ test('call eth_getBlockByNumber with false for second argument', t => {
 })
 
 test('call eth_getBlockByNumber with invalid block number', t => {
-  const manager = createManager(createNode())
+  const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -134,7 +117,7 @@ test('call eth_getBlockByNumber with invalid block number', t => {
 })
 
 test('call eth_getBlockByNumber without second parameter', t => {
-  const manager = createManager(createNode())
+  const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -162,7 +145,7 @@ test('call eth_getBlockByNumber without second parameter', t => {
 })
 
 test('call eth_getBlockByNumber with invalid second parameter', t => {
-  const manager = createManager(createNode())
+  const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
   const req = {

--- a/test/rpc/eth/protocolVersion.js
+++ b/test/rpc/eth/protocolVersion.js
@@ -3,13 +3,13 @@ const test = require('tape')
 const request = require('supertest')
 const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
-test('call net_peerCount', t => {
-  const manager = createManager(createNode({ opened: true }))
+test('call eth_protocolVersion ', t => {
+  const manager = createManager(createNode())
   const server = startRPC(manager.getMethods())
 
   const req = {
     jsonrpc: '2.0',
-    method: 'net_peerCount',
+    method: 'eth_protocolVersion',
     params: [],
     id: 1
   }
@@ -20,9 +20,9 @@ test('call net_peerCount', t => {
     .send(req)
     .expect(200)
     .expect(res => {
-      const { result } = res.body
-      if (result.substring(0, 2) !== '0x') {
-        throw new Error('Result should be a hex number, but is not')
+      const responseBlob = res.body
+      if (typeof responseBlob.result !== 'string') {
+        throw new Error('Protocol version is not a string')
       }
     })
     .end((err, res) => {

--- a/test/rpc/helpers.js
+++ b/test/rpc/helpers.js
@@ -1,10 +1,14 @@
 const jayson = require('jayson')
+const Common = require('ethereumjs-common')
 
 const Manager = require('../../lib/rpc')
 const Logger = require('../../lib/logging')
+const blockChain = require('./blockChainStub.js')
+const Chain = require('../../lib/blockchain/chain.js')
 
 const config = { loglevel: 'error' }
 config.logger = Logger.getLogger(config)
+
 module.exports = {
   startRPC (methods, port = 3000) {
     const server = jayson.server(methods)
@@ -19,5 +23,27 @@ module.exports = {
 
   createManager (node) {
     return new Manager(node, config)
+  },
+
+  createNode (nodeConfig) {
+    const chain = new Chain({ blockchain: blockChain({}) })
+    chain.opened = true
+    const defaultNodeConfig = { blockchain: chain, opened: true, commonChain: new Common('mainnet'), ethProtocolVersions: [63] }
+    const trueNodeConfig = { ...defaultNodeConfig, ...nodeConfig }
+    return {
+      services: [
+        {
+          name: 'eth',
+          chain: trueNodeConfig.blockchain,
+          pool: { peers: [1, 2, 3] },
+          protocols: [{
+            name: 'eth',
+            versions: trueNodeConfig.ethProtocolVersions
+          }]
+        }
+      ],
+      common: trueNodeConfig.commonChain,
+      opened: trueNodeConfig.opened
+    }
   }
 }

--- a/test/rpc/net/listening.js
+++ b/test/rpc/net/listening.js
@@ -1,31 +1,10 @@
 const test = require('tape')
 
 const request = require('supertest')
-const Common = require('ethereumjs-common')
-const { startRPC, closeRPC, createManager } = require('../helpers')
-const blockChain = require('../blockChainStub.js')
-const Chain = require('../../../lib/blockchain/chain.js')
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  let chain = new Chain({ blockchain: blockChain({}) })
-  chain.opened = true
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: chain,
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
-  }
-}
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 test('call net_listening while listening', t => {
-  const manager = createManager(createNode(true))
+  const manager = createManager(createNode({ opened: true }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -57,7 +36,7 @@ test('call net_listening while listening', t => {
 })
 
 test('call net_listening while not listening', t => {
-  const manager = createManager(createNode(false))
+  const manager = createManager(createNode({ opened: false }))
   const server = startRPC(manager.getMethods())
 
   const req = {

--- a/test/rpc/net/version.js
+++ b/test/rpc/net/version.js
@@ -2,30 +2,10 @@ const test = require('tape')
 
 const request = require('supertest')
 const Common = require('ethereumjs-common')
-const { startRPC, closeRPC, createManager } = require('../helpers')
-const blockChain = require('../blockChainStub.js')
-const Chain = require('../../../lib/blockchain/chain.js')
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  let chain = new Chain({ blockchain: blockChain({}) })
-  chain.opened = true
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: chain,
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
-  }
-}
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 test('call net_version on ropsten', t => {
-  const manager = createManager(createNode(true, new Common('ropsten')))
+  const manager = createManager(createNode({ opened: true, commonChain: new Common('ropsten') }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -99,7 +79,7 @@ test('call net_version on mainnet', t => {
 })
 
 test('call net_version on rinkeby', t => {
-  const manager = createManager(createNode(true, new Common('rinkeby')))
+  const manager = createManager(createNode({ opened: true, commonChain: new Common('rinkeby') }))
   const server = startRPC(manager.getMethods())
 
   const req = {
@@ -136,7 +116,7 @@ test('call net_version on rinkeby', t => {
 })
 
 test('call net_version on kovan', t => {
-  const manager = createManager(createNode(true, new Common('kovan')))
+  const manager = createManager(createNode({ opened: true, commonChain: new Common('kovan') }))
   const server = startRPC(manager.getMethods())
 
   const req = {

--- a/test/rpc/web3/clientVersion.js
+++ b/test/rpc/web3/clientVersion.js
@@ -2,28 +2,7 @@ const test = require('tape')
 
 const { platform } = require('os')
 const request = require('supertest')
-const Common = require('ethereumjs-common')
-const { startRPC, closeRPC, createManager } = require('../helpers')
-const blockChain = require('../blockChainStub.js')
-const Chain = require('../../../lib/blockchain/chain.js')
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  let chain = new Chain({ blockchain: blockChain({}) })
-  chain.opened = true
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: chain,
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
-  }
-}
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 test('call web3_clientVersion', t => {
   const manager = createManager(createNode())

--- a/test/rpc/web3/sha3.js
+++ b/test/rpc/web3/sha3.js
@@ -1,28 +1,7 @@
 const test = require('tape')
 
 const request = require('supertest')
-const Common = require('ethereumjs-common')
-const { startRPC, closeRPC, createManager } = require('../helpers')
-const blockChain = require('../blockChainStub.js')
-const Chain = require('../../../lib/blockchain/chain.js')
-
-function createNode (opened = true, commonChain = new Common('mainnet')) {
-  let chain = new Chain({ blockchain: blockChain({}) })
-  chain.opened = true
-  return {
-    services: [
-      {
-        name: 'eth',
-        chain: chain,
-        synchronizer: {
-          pool: { peers: [1, 2, 3] }
-        }
-      }
-    ],
-    common: commonChain,
-    opened
-  }
-}
+const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 test('call web3_sha3 with one valid parameter', t => {
   const manager = createManager(createNode())

--- a/test/service/ethereumservice.js
+++ b/test/service/ethereumservice.js
@@ -5,7 +5,7 @@ const { defaultLogger } = require('../../lib/logging')
 defaultLogger.silent = true
 
 tape('[EthereumService]', t => {
-  class PeerPool extends EventEmitter {}
+  class PeerPool extends EventEmitter { }
   PeerPool.prototype.open = td.func()
   td.replace('../../lib/net/peerpool', PeerPool)
   td.replace('../../lib/net/protocol/flowcontrol')
@@ -19,8 +19,8 @@ tape('[EthereumService]', t => {
   const LesProtocol = td.constructor()
   td.replace('../../lib/net/protocol/ethprotocol', EthProtocol)
   td.replace('../../lib/net/protocol/lesprotocol', LesProtocol)
-  class FastSynchronizer extends EventEmitter {}
-  class LightSynchronizer extends EventEmitter {}
+  class FastSynchronizer extends EventEmitter { }
+  class LightSynchronizer extends EventEmitter { }
   LightSynchronizer.prototype.sync = td.func()
   LightSynchronizer.prototype.stop = td.func()
   LightSynchronizer.prototype.open = td.func()
@@ -29,23 +29,23 @@ tape('[EthereumService]', t => {
   const EthereumService = require('../../lib/service/ethereumservice')
 
   t.test('should initialize correctly', async (t) => {
-    let service = new EthereumService({syncmode: 'light'})
+    let service = new EthereumService({ syncmode: 'light' })
     t.ok(service.synchronizer instanceof LightSynchronizer, 'light mode')
-    service = new EthereumService({syncmode: 'fast', lightserv: true})
+    service = new EthereumService({ syncmode: 'fast', lightserv: true })
     t.ok(service.synchronizer instanceof FastSynchronizer, 'fast mode')
     t.ok(service.handlers[0] instanceof EthHandler, 'eth handler')
     t.ok(service.handlers[1] instanceof LesHandler, 'les handler')
-    t.throws(() => new EthereumService({syncmode: 'unknown'}), /Unsupported/, 'bad syncmode')
+    t.throws(() => new EthereumService({ syncmode: 'unknown' }), /Unsupported/, 'bad syncmode')
     t.equals(service.name, 'eth', 'got name')
     t.end()
   })
 
   t.test('should get protocols', async (t) => {
-    let service = new EthereumService({syncmode: 'light'})
-    t.ok(service.protocols()[0] instanceof LesProtocol, 'light protocols')
-    service = new EthereumService({syncmode: 'fast', lightserv: true})
-    t.ok(service.protocols()[0] instanceof EthProtocol, 'fast protocols')
-    t.ok(service.protocols()[1] instanceof LesProtocol, 'lightserv protocols')
+    let service = new EthereumService({ syncmode: 'light' })
+    t.ok(service.protocols[0] instanceof LesProtocol, 'light protocols')
+    service = new EthereumService({ syncmode: 'fast', lightserv: true })
+    t.ok(service.protocols[0] instanceof EthProtocol, 'fast protocols')
+    t.ok(service.protocols[1] instanceof LesProtocol, 'lightserv protocols')
     t.end()
   })
 
@@ -53,7 +53,7 @@ tape('[EthereumService]', t => {
     t.plan(3)
     const server = td.object()
     let service = new EthereumService({
-      servers: [ server ]
+      servers: [server]
     })
     await service.open()
     td.verify(service.chain.open())
@@ -72,7 +72,7 @@ tape('[EthereumService]', t => {
 
   t.test('should start/stop', async (t) => {
     const server = td.object()
-    let service = new EthereumService({servers: [server]})
+    let service = new EthereumService({ servers: [server] })
     await service.start()
     td.verify(service.synchronizer.sync())
     t.notOk(await service.start(), 'already started')


### PR DESCRIPTION
Adding `eth_protocolVersion`.  

Also abstracting the `createNode` function to the test helpers file, because every RPC test calls the function and it's best not to repeat its implementation in every RPC test.