### PR TITLE
Add Goerli Support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-const Common = require('ethereumjs-common')
-const chains = require('ethereumjs-common/chains')
+const Common = require('ethereumjs-common').default
+const chains = require('ethereumjs-common/dist/chains').chains
 const { getLogger } = require('../lib/logging')
 const { parse } = require('../lib/util')
 const { fromName: serverFromName } = require('../lib/net/server')

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events')
-const Common = require('ethereumjs-common')
+const Common = require('ethereumjs-common').default
 const Block = require('ethereumjs-block')
 const Blockchain = require('ethereumjs-blockchain')
 const { BN } = require('ethereumjs-util')

--- a/lib/service/ethereumservice.js
+++ b/lib/service/ethereumservice.js
@@ -3,7 +3,7 @@
 const Service = require('./service')
 const FlowControl = require('../net/protocol/flowcontrol')
 const { Chain } = require('../blockchain')
-const Common = require('ethereumjs-common')
+const Common = require('ethereumjs-common').default
 
 const defaultOptions = {
   lightserv: false,

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "ethereumjs-account": "^2.0.5",
-    "ethereumjs-block": "^2.1.0",
-    "ethereumjs-blockchain": "^3.3.2",
-    "ethereumjs-common": "^0.6.1",
+    "ethereumjs-block": "^2.2.0",
+    "ethereumjs-blockchain": "^3.4.0",
+    "ethereumjs-common": "^1.1.0",
     "ethereumjs-devp2p": "^2.5.1",
     "ethereumjs-util": "^6.0.0",
     "fs-extra": "^6.0.1",

--- a/test/rpc/helpers.js
+++ b/test/rpc/helpers.js
@@ -1,5 +1,5 @@
 const jayson = require('jayson')
-const Common = require('ethereumjs-common')
+const Common = require('ethereumjs-common').default
 
 const Manager = require('../../lib/rpc')
 const Logger = require('../../lib/logging')

--- a/test/rpc/net/version.js
+++ b/test/rpc/net/version.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const request = require('supertest')
-const Common = require('ethereumjs-common')
+const Common = require('ethereumjs-common').default
 const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
 
 test('call net_version on ropsten', t => {
@@ -145,6 +145,45 @@ test('call net_version on kovan', t => {
       if (result !== '42') {
         throw new Error(
           `Incorrect chain ID. Expected: 42, Received: ${result}`
+        )
+      }
+    })
+    .end((err, res) => {
+      closeRPC(server)
+      t.end(err)
+    })
+})
+
+test('call net_version on goerli', t => {
+  const manager = createManager(createNode({ opened: true, commonChain: new Common('goerli') }))
+  const server = startRPC(manager.getMethods())
+
+  const req = {
+    jsonrpc: '2.0',
+    method: 'net_version',
+    params: [],
+    id: 1
+  }
+
+  request(server)
+    .post('/')
+    .set('Content-Type', 'application/json')
+    .send(req)
+    .expect(200)
+    .expect(res => {
+      const { result } = res.body
+
+      if (typeof result !== 'string') {
+        throw new Error('Result should be a string, but is not')
+      }
+
+      if (result.length === 0) {
+        throw new Error('Empty result string')
+      }
+
+      if (result !== '5') {
+        throw new Error(
+          `Incorrect chain ID. Expected: 5, Received: ${result}`
         )
       }
     })


### PR DESCRIPTION
This works syncing on the final version of the Goerli testnet:

```shell
./bin/cli.js --network=goerli
INFO [02-07|13:59:14] Data directory: /Users/hdrewes/Library/Ethereum/goerli/ethereumjs/chaindata
INFO [02-07|13:59:14] Initializing Ethereumjs client...
INFO [02-07|13:59:14] Fast sync mode
INFO [02-07|13:59:14] Connecting to network: goerli
INFO [02-07|13:59:14] Latest local block: number=0 td=1 hash=bf7e331f...
INFO [02-07|13:59:14] Synchronizing blockchain...
INFO [02-07|13:59:14] Started rlpx server.
INFO [02-07|13:59:14] Started libp2p server.
INFO [02-07|13:59:14] Listener up transport=rlpx url=enode://b323435b016cb8e10d53c70890daf09621b9cc2207ec4b861d2c60b9287cb1a4d45768ba243b01422bc847b0259a250d2d1a1a41845df06d7cbf7ae4a9246a63@[::]:30303
INFO [02-07|13:59:15] Listener up transport=libp2p url=/ip4/127.0.0.1/tcp/50580/ws/ipfs/QmZJuoW98KjdpxWpPZTtMUaGQdoRJ3rmgCdAhEsipZky3Y
INFO [02-07|13:59:15] Started eth service.
INFO [02-07|13:59:46] Imported blocks count=128 number=1 hash=8f5bab21... peers=1
INFO [02-07|13:59:48] Imported blocks count=256 number=129 hash=831d8538... peers=1
INFO [02-07|13:59:50] Imported blocks count=512 number=385 hash=e849bd62... peers=1
INFO [02-07|13:59:54] Imported blocks count=1024 number=897 hash=2da235c0... peers=1
INFO [02-07|13:59:58] Imported blocks count=1024 number=1921 hash=2bb6b20c... peers=1
INFO [02-07|13:59:58] Imported blocks count=128 number=2945 hash=abcc6f40... peers=1
INFO [02-07|14:00:05] Imported blocks count=1920 number=3073 hash=d8aa8483... peers=1
INFO [02-07|14:00:05] Imported blocks count=128 number=4993 hash=299148c0... peers=1
```

Would be cool to have this integrated, since on https://github.com/goerli/testnet they are still referring to the preliminary test version.