### PR TITLE
Fixed error handling for id-less peers

### DIFF
--- a/lib/net/server/rlpxserver.js
+++ b/lib/net/server/rlpxserver.js
@@ -210,7 +210,11 @@ class RlpxServer extends Server {
     })
 
     this.rlpx.on('peer:error', (rlpxPeer, error) => {
-      const id = rlpxPeer.getId().toString('hex')
+      const peerId = rlpxPeer && rlpxPeer.getId()
+      if (!peerId) {
+        return this.error(error)
+      }
+      const id = peerId.toString('hex')
       const peer = this.peers.get(id)
       this.error(error, peer)
     })

--- a/test/net/server/rlpxserver.js
+++ b/test/net/server/rlpxserver.js
@@ -114,6 +114,17 @@ tape('[RlpxServer]', t => {
     server.rlpx.emit('listening')
   })
 
+  t.test('should handles errors from id-less peers', t => {
+    t.plan(1)
+    const server = new RlpxServer()
+    const rlpxPeer = td.object()
+    td.when(rlpxPeer.getId()).thenReturn(null)
+    td.when(RlpxPeer.prototype.accept(rlpxPeer, td.matchers.isA(RlpxServer))).thenResolve()
+    server.initRlpx()
+    server.on('error', err => t.equals(err, 'err0', 'got error'))
+    server.rlpx.emit('peer:error', rlpxPeer, 'err0')
+  })
+
   t.test('should reset td', t => {
     td.reset()
     t.end()


### PR DESCRIPTION
It's possible that an RLPx peer without a remote ID has an error. We need to properly handle that case in the ``peer:error`` event handler in ``RlpxServer``.

Closes #96 