### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -249,3 +249,9 @@ No meaningful new PR will be accepted without associated tests (exceptions might
 a case-by-case basis). Test coverage should not increase (significantly) by a new PR.
 You might also want to consider writing your tests first and then directly push them,
 since this would be a good starting point for discussing the scope/implementation of a feature.
+
+## EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "test": "npm run lint && npm run unit && npm run integration",
     "build": "npm run test && browserify browser/index.js -s ethereumjs -t babelify --outfile dist/bundle.js"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "browser": {
     "./lib/net/peer/libp2pnode.js": "./browser/libp2pnode.js",
     "./lib/logging": "./browser/logging.js"
@@ -86,6 +91,7 @@
     "babelify": "^10.0.0",
     "browserify": "^16.2.3",
     "coveralls": "^3.0.0",
+    "husky": "^2.1.0",
     "json-to-markdown": "^1.0.4",
     "level-browserify": "^2.0.0",
     "nyc": "~13.3.0",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.