### PR TITLE
Explicitly initialize Common instances with chainstart HF

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -114,7 +114,10 @@ async function run () {
   const syncDirName = args.syncmode === 'light' ? 'lightchaindata' : 'chaindata'
   const networkDirName = args.network === 'mainnet' ? '' : `${args.network}/`
   const chainParams = args.params ? await parse.params(args.params) : args.network
-  const common = new Common(chainParams)
+  // Initialize Common with an explicit 'chainstart' HF set until
+  // hardfork awareness is implemented within the library
+  // Also a fix for https://github.com/ethereumjs/ethereumjs-vm/issues/757
+  const common = new Common(chainParams, 'chainstart')
   const servers = parse.transports(args.transports).map(t => {
     const Server = serverFromName(t.name)
     if (t.name === 'rlpx') {

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -10,7 +10,7 @@ const promisify = require('util-promisify')
 
 const defaultOptions = {
   logger: defaultLogger,
-  common: new Common('mainnet')
+  common: new Common('mainnet', 'chainstart')
 }
 
 /**

--- a/lib/service/ethereumservice.js
+++ b/lib/service/ethereumservice.js
@@ -7,7 +7,7 @@ const Common = require('ethereumjs-common').default
 
 const defaultOptions = {
   lightserv: false,
-  common: new Common('mainnet'),
+  common: new Common('mainnet', 'chainstart'),
   minPeers: 3,
   timeout: 5000,
   interval: 1000


### PR DESCRIPTION
Fixes https://github.com/ethereumjs/ethereumjs-vm/issues/757

This was triggered (repeatedly) during block synchronization:

```shell
INFO [05-28|17:50:53] Imported blocks count=256 number=45441 hash=97e6df8e... peers=2
INFO [05-28|17:50:53] Imported blocks count=128 number=45697 hash=cec4ec8f... peers=2
INFO [05-28|17:50:54] Imported blocks count=128 number=45825 hash=b48ff3a6... peers=2
INFO [05-28|17:50:54] Imported blocks count=128 number=45953 hash=09765b76... peers=2
ERROR [05-28|17:50:55] Error: Method called with neither a hardfork set nor provided by param
    at Common._chooseHardfork (/ethereumjs-client/node_modules/ethereumjs-common/dist/index.js:114:23)
    at Common.hardforkGteHardfork (/ethereumjs-client/node_modules/ethereumjs-common/dist/index.js:228:26)
    at Common.gteHardfork (/ethereumjs-client/node_modules/ethereumjs-common/dist/index.js:255:21)
    at Transaction._validateV (/ethereumjs-client/node_modules/ethereumjs-tx/dist/transaction.js:301:27)
    at new Transaction (/ethereumjs-client/node_modules/ethereumjs-tx/dist/transaction.js:138:14)
    at new module.exports (/ethereumjs-client/node_modules/ethereumjs-block/index.js:75:14)
    at /ethereumjs-client/lib/blockchain/chain.js:208:30
    at Array.map (<anonymous>)
    at Chain.putBlocks (/ethereumjs-client/lib/blockchain/chain.js:208:21)
    at BlockFetcher.store (/ethereumjs-client/lib/sync/fetcher/blockfetcher.js:89:22)
```