### PR TITLE
remove old fields `consensus` and `finality`

### DIFF
--- a/lib/util/parse.js
+++ b/lib/util/parse.js
@@ -137,9 +137,7 @@ async function parseGethParams (json) {
   }
   params.hardforks = hardforks.map(name => ({
     name: name,
-    block: name === 'chainstart' ? 0 : json.config[forkMap[name]] || null,
-    consensus: json.config.clique ? 'poa' : 'pow',
-    finality: name === 'hybridCasper' ? 'pos' : null
+    block: name === 'chainstart' ? 0 : json.config[forkMap[name]] || null
   }))
   return params
 }

--- a/test/util/params.json
+++ b/test/util/params.json
@@ -22,43 +22,27 @@
   "bootstrapNodes": [],
   "hardforks": [{
     "name": "chainstart",
-    "block": 0,
-    "consensus": "poa",
-    "finality": null
+    "block": 0
   }, {
     "name": "homestead",
-    "block": 1,
-    "consensus": "poa",
-    "finality": null
+    "block": 1
   }, {
     "name": "dao",
-    "block": null,
-    "consensus": "poa",
-    "finality": null
+    "block": null
   }, {
     "name": "tangerineWhistle",
-    "block": 2,
-    "consensus": "poa",
-    "finality": null
+    "block": 2
   }, {
     "name": "spuriousDragon",
-    "block": 3,
-    "consensus": "poa",
-    "finality": null
+    "block": 3
   }, {
     "name": "byzantium",
-    "block": 1035301,
-    "consensus": "poa",
-    "finality": null
+    "block": 1035301
   }, {
     "name": "constantinople",
-    "block": null,
-    "consensus": "poa",
-    "finality": null
+    "block": null
   }, {
     "name": "hybridCasper",
-    "block": null,
-    "consensus": "poa",
-    "finality": "pos"
+    "block": null
   }]
 }


### PR DESCRIPTION
This PR follows https://github.com/ethereumjs/ethereumjs-vm/pull/758 to remove unused fields `consensus` and `finality`.