### PR TITLE
RPC test method cleanup

### DIFF
--- a/test/rpc/eth/getBlockByHash.js
+++ b/test/rpc/eth/getBlockByHash.js
@@ -1,176 +1,81 @@
 const test = require('tape')
 
-const request = require('supertest')
 const { INVALID_PARAMS } = require('../../../lib/rpc/error-code')
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { baseSetup, params, baseRequest } = require('../helpers')
 const { checkError } = require('../util')
 
-test('call eth_getBlockByHash with valid arguments', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+const method = 'eth_getBlockByHash'
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: [
-      '0x910abca1728c53e8d6df870dd7af5352e974357dc58205dea1676be17ba6becf',
-      true
-    ],
-    id: 1
+test(`${method}: call with valid arguments`, t => {
+  const server = baseSetup()
+
+  const req = params(method, [
+    '0x910abca1728c53e8d6df870dd7af5352e974357dc58205dea1676be17ba6becf',
+    true
+  ])
+  const expectRes = res => {
+    let msg = 'should return the correct number'
+    t.equal(res.body.result.number, 444444, msg)
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      if (res.body.result.number !== 444444) {
-        throw new Error('number is not 444444')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockByHash with false for second argument', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with false for second argument`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: [
-      '0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae',
-      false
-    ],
-    id: 1
+  const req = params(method, [
+    '0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae',
+    false
+  ])
+  const expectRes = res => {
+    let msg = 'should return the correct number'
+    t.equal(res.body.result.number, 444444, msg)
+    msg = 'should return only the hashes of the transactions'
+    t.equal(typeof (res.body.result.transactions[0]), 'string', msg)
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      if (res.body.result.number !== 444444) {
-        throw new Error('number is not 444444')
-      }
-      if (typeof res.body.result.transactions[0] !== 'string') {
-        throw new Error('only the hashes of the transactions')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockByHash with invalid block hash without 0x', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with invalid block hash without 0x`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: ['WRONG BLOCK NUMBER', true],
-    id: 1
-  }
-  const checkInvalidParams = checkError(
+  const req = params(method, ['WRONG BLOCK NUMBER', true])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'invalid argument 0: hex string without 0x prefix'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockByHash with invalid hex string as block hash', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with invalid hex string as block hash`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: ['0xWRONG BLOCK NUMBER', true],
-    id: 1
-  }
-  const checkInvalidParams = checkError(
+  const req = params(method, ['0xWRONG BLOCK NUMBER', true])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'invalid argument 0: invalid block hash'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
 test('call eth_getBlockByHash without second parameter', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: ['0x0'],
-    id: 1
-  }
-
-  const checkInvalidParams = checkError(
+  const req = params(method, ['0x0'])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'missing value for required argument 1'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
 test('call eth_getBlockByHash with invalid second parameter', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockByHash',
-    params: ['0x0', 'INVALID PARAMETER'],
-    id: 1
-  }
-
-  const checkInvalidParams = checkError(INVALID_PARAMS)
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  const req = params(method, ['0x0', 'INVALID PARAMETER'])
+  const expectRes = checkError(t, INVALID_PARAMS)
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/eth/getBlockTransactionCountByHash.js
+++ b/test/rpc/eth/getBlockTransactionCountByHash.js
@@ -1,142 +1,68 @@
 const test = require('tape')
 
-const request = require('supertest')
 const { INVALID_PARAMS } = require('../../../lib/rpc/error-code')
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { baseSetup, params, baseRequest } = require('../helpers')
 const { checkError } = require('../util')
 
-test('call eth_getBlockTransactionCountByHash with valid arguments', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+const method = 'eth_getBlockTransactionCountByHash'
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockTransactionCountByHash',
-    params: [
-      '0x910abca1728c53e8d6df870dd7af5352e974357dc58205dea1676be17ba6becf'
-    ],
-    id: 1
+test(`${method}: call with valid arguments`, t => {
+  const server = baseSetup()
+
+  const req = params(method, [
+    '0x910abca1728c53e8d6df870dd7af5352e974357dc58205dea1676be17ba6becf'
+  ])
+  const expectRes = res => {
+    const msg = 'transaction count should be 1'
+    if (res.body.result !== `0x1`) {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      if (res.body.result !== `0x1`) {
-        throw new Error('transaction count is not 1')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockTransactionCountByHash with invalid block hash without 0x', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with invalid block hash without 0x`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockTransactionCountByHash',
-    params: ['WRONG BLOCK NUMBER'],
-    id: 1
-  }
-  const checkInvalidParams = checkError(
+  const req = params(method, ['WRONG BLOCK NUMBER'])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'invalid argument 0: hex string without 0x prefix'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockTransactionCountByHash with invalid hex string as block hash', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with invalid hex string as block hash`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockTransactionCountByHash',
-    params: ['0xWRONG BLOCK NUMBER', true],
-    id: 1
-  }
-  const checkInvalidParams = checkError(
+  const req = params(method, ['0xWRONG BLOCK NUMBER', true])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'invalid argument 0: invalid block hash'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockTransactionCountByHash without first parameter', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call without first parameter`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockTransactionCountByHash',
-    params: [],
-    id: 1
-  }
-
-  const checkInvalidParams = checkError(
+  const req = params(method, [])
+  const expectRes = checkError(
+    t,
     INVALID_PARAMS,
     'missing value for required argument 0'
   )
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockTransactionCountByHash with invalid second parameter', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call with invalid second parameter`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_getBlockTransactionCountByHash',
-    params: ['INVALID PARAMETER'],
-    id: 1
-  }
-
-  const checkInvalidParams = checkError(INVALID_PARAMS)
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(checkInvalidParams)
-    .end(err => {
-      closeRPC(server)
-      t.end(err)
-    })
+  const req = params(method, ['INVALID PARAMETER'])
+  const expectRes = checkError(t, INVALID_PARAMS)
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/eth/protocolVersion.js
+++ b/test/rpc/eth/protocolVersion.js
@@ -1,32 +1,21 @@
 const test = require('tape')
 
-const request = require('supertest')
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { baseSetup, params, baseRequest } = require('../helpers')
 
-test('call eth_protocolVersion ', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+const method = 'eth_protocolVersion'
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'eth_protocolVersion',
-    params: [],
-    id: 1
+test(`${method}: call`, t => {
+  const server = baseSetup()
+
+  const req = params(method, [])
+  const expectRes = res => {
+    const responseBlob = res.body
+    const msg = 'protocol version should be a string'
+    if (typeof responseBlob.result !== 'string') {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const responseBlob = res.body
-      if (typeof responseBlob.result !== 'string') {
-        throw new Error('Protocol version is not a string')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/helpers.js
+++ b/test/rpc/helpers.js
@@ -1,4 +1,5 @@
 const jayson = require('jayson')
+const request = require('supertest')
 const Common = require('ethereumjs-common').default
 
 const Manager = require('../../lib/rpc')
@@ -45,5 +46,34 @@ module.exports = {
       common: trueNodeConfig.commonChain,
       opened: trueNodeConfig.opened
     }
+  },
+
+  baseSetup () {
+    const manager = module.exports.createManager(module.exports.createNode())
+    const server = module.exports.startRPC(manager.getMethods())
+    return server
+  },
+
+  params (method, params) {
+    const req = {
+      jsonrpc: '2.0',
+      method: method,
+      params: params,
+      id: 1
+    }
+    return req
+  },
+
+  baseRequest (t, server, req, expect, expectRes) {
+    request(server)
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .send(req)
+      .expect(expect)
+      .expect(expectRes)
+      .end((err, res) => {
+        module.exports.closeRPC(server)
+        t.end(err)
+      })
   }
 }

--- a/test/rpc/net/listening.js
+++ b/test/rpc/net/listening.js
@@ -1,68 +1,53 @@
 const test = require('tape')
 
-const request = require('supertest')
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { startRPC, createManager, createNode, params, baseRequest } = require('../helpers')
 
-test('call net_listening while listening', t => {
+const method = 'net_listening'
+
+test(`${method}: call while listening`, t => {
   const manager = createManager(createNode({ opened: true }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_listening',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    let msg = 'result should be a boolean'
+    if (typeof result !== 'boolean') {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
+
+    msg = 'should be listening'
+    if (result !== true) {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-      if (typeof result !== 'boolean') {
-        throw new Error('Result should be a boolean, but is not')
-      }
-
-      if (result !== true) {
-        throw new Error('Not listening, when it should be')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call net_listening while not listening', t => {
+test(`${method}: call while not listening`, t => {
   const manager = createManager(createNode({ opened: false }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_listening',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    let msg = 'result should be a boolean'
+    if (typeof result !== 'boolean') {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
+
+    msg = 'should not be listening'
+    if (result !== false) {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-      if (typeof result !== 'boolean') {
-        throw new Error('Result should be a boolean, but is not')
-      }
-
-      if (result !== false) {
-        throw new Error('Listening, when it not should be')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/net/peerCount.js
+++ b/test/rpc/net/peerCount.js
@@ -1,32 +1,22 @@
 const test = require('tape')
 
-const request = require('supertest')
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { startRPC, createManager, createNode, params, baseRequest } = require('../helpers')
 
-test('call net_peerCount', t => {
+const method = 'net_peerCount'
+
+test(`${method}: call`, t => {
   const manager = createManager(createNode({ opened: true }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_peerCount',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    const msg = 'result should be a hex number'
+    if (result.substring(0, 2) !== '0x') {
+      throw new Error(msg)
+    } else {
+      t.pass(msg)
+    }
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-      if (result.substring(0, 2) !== '0x') {
-        throw new Error('Result should be a hex number, but is not')
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/net/version.js
+++ b/test/rpc/net/version.js
@@ -1,194 +1,88 @@
 const test = require('tape')
 
-const request = require('supertest')
 const Common = require('ethereumjs-common').default
-const { startRPC, closeRPC, createManager, createNode } = require('../helpers')
+const { startRPC, createManager, createNode, baseSetup, params, baseRequest } = require('../helpers')
 
-test('call net_version on ropsten', t => {
+const method = 'net_version'
+
+function compareResult (t, result, chainId) {
+  let msg = 'result should be a string'
+  if (typeof result !== 'string') {
+    throw new Error(msg)
+  } else {
+    t.pass(msg)
+  }
+
+  msg = 'result string should not be empty'
+  if (result.length === 0) {
+    throw new Error(msg)
+  } else {
+    t.pass(msg)
+  }
+
+  msg = `should be the correct chain ID (expected: ${chainId}, received: ${result})`
+  if (result !== chainId) {
+    throw new Error(msg)
+  } else {
+    t.pass(msg)
+  }
+}
+
+test(`${method}: call on ropsten`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('ropsten') }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_version',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    compareResult(t, result, '3')
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-
-      if (typeof result !== 'string') {
-        throw new Error('Result should be a string, but is not')
-      }
-
-      if (result.length === 0) {
-        throw new Error('Empty result string')
-      }
-
-      if (result !== '3') {
-        throw new Error(`Incorrect chain ID. Expected: 3, Received: ${result}`)
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call net_version on mainnet', t => {
-  const manager = createManager(createNode())
-  const server = startRPC(manager.getMethods())
+test(`${method}: call on mainnet`, t => {
+  const server = baseSetup()
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_version',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    compareResult(t, result, '1')
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-
-      if (typeof result !== 'string') {
-        throw new Error('Result should be a string, but is not')
-      }
-
-      if (result.length === 0) {
-        throw new Error('Empty result string')
-      }
-
-      if (result !== '1') {
-        throw new Error(`Incorrect chain ID. Expected: 1, Received: ${result}`)
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call net_version on rinkeby', t => {
+test(`${method}: call on rinkeby`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('rinkeby') }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_version',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    compareResult(t, result, '4')
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-
-      if (typeof result !== 'string') {
-        throw new Error('Result should be a string, but is not')
-      }
-
-      if (result.length === 0) {
-        throw new Error('Empty result string')
-      }
-
-      if (result !== '4') {
-        throw new Error(`Incorrect chain ID. Expected: 4, Received: ${result}`)
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call net_version on kovan', t => {
+test(`${method}: call on kovan`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('kovan') }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_version',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    compareResult(t, result, '42')
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-
-      if (typeof result !== 'string') {
-        throw new Error('Result should be a string, but is not')
-      }
-
-      if (result.length === 0) {
-        throw new Error('Empty result string')
-      }
-
-      if (result !== '42') {
-        throw new Error(
-          `Incorrect chain ID. Expected: 42, Received: ${result}`
-        )
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call net_version on goerli', t => {
+test(`${method}: call on goerli`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('goerli') }))
   const server = startRPC(manager.getMethods())
 
-  const req = {
-    jsonrpc: '2.0',
-    method: 'net_version',
-    params: [],
-    id: 1
+  const req = params(method, [])
+  const expectRes = res => {
+    const { result } = res.body
+    compareResult(t, result, '5')
   }
-
-  request(server)
-    .post('/')
-    .set('Content-Type', 'application/json')
-    .send(req)
-    .expect(200)
-    .expect(res => {
-      const { result } = res.body
-
-      if (typeof result !== 'string') {
-        throw new Error('Result should be a string, but is not')
-      }
-
-      if (result.length === 0) {
-        throw new Error('Empty result string')
-      }
-
-      if (result !== '5') {
-        throw new Error(
-          `Incorrect chain ID. Expected: 5, Received: ${result}`
-        )
-      }
-    })
-    .end((err, res) => {
-      closeRPC(server)
-      t.end(err)
-    })
+  baseRequest(t, server, req, 200, expectRes)
 })

--- a/test/rpc/util.js
+++ b/test/rpc/util.js
@@ -1,6 +1,6 @@
 module.exports = {
-  checkError (expectedCode, expectedMessage) {
-    return function (res) {
+  checkError (t, expectedCode, expectedMessage) {
+    return (res) => {
       if (!res.body.error) {
         throw new Error('should return an error object')
       }
@@ -10,6 +10,7 @@ module.exports = {
       if (expectedMessage && res.body.error.message !== expectedMessage) {
         throw new Error(`should have an error message "${expectedMessage}"`)
       }
+      t.pass('should return error object with error code and message')
     }
   }
 }


### PR DESCRIPTION
This PR simplifies & wraps common code parts of the RPC test methods since there is so much code redundancy which will likely get a bit out of hand if we continue with so much copy-and-paste.

Have done this for one file only (`getBlockByHash`) for now and would apply to all RPC test files after some feedback here.