### PR TITLE
fix(rpc): handle rpc request with empty params

### DIFF
--- a/lib/rpc/validation.js
+++ b/lib/rpc/validation.js
@@ -8,7 +8,7 @@ module.exports = {
    * @param {Function[]} validators      array of validator
    */
   middleware (method, requiredParamsCount, validators) {
-    return function (params, cb) {
+    return function (params = [], cb) {
       if (params.length < requiredParamsCount) {
         const err = {
           code: INVALID_PARAMS,

--- a/test/rpc/validation.js
+++ b/test/rpc/validation.js
@@ -1,0 +1,52 @@
+
+const test = require('tape')
+
+const { startRPC } = require('./helpers')
+const { middleware } = require('../../lib/rpc/validation')
+const { baseRequest } = require('./helpers')
+const { checkError } = require('./util')
+const { INVALID_PARAMS } = require('../../lib/rpc/error-code')
+
+const prefix = 'rpc/validation:'
+
+test(`${prefix} should work without \`params\` when it's optional`, t => {
+  const mockMethodName = 'mock'
+  const server = startRPC({
+    [mockMethodName]: middleware((params, cb) => {
+      cb()
+    }, 0, [])
+  })
+
+  const req = {
+    jsonrpc: '2.0',
+    method: mockMethodName,
+    id: 1
+  }
+  const expectRes = res => {
+    t.equal(res.body.error, undefined, 'should not return an error object')
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})
+
+test(`${prefix} should return error without \`params\` when it's required`, t => {
+  const mockMethodName = 'mock'
+  const server = startRPC({
+    [mockMethodName]: middleware((params, cb) => {
+      cb()
+    }, 1, [])
+  })
+
+  const req = {
+    jsonrpc: '2.0',
+    method: mockMethodName,
+    id: 1
+  }
+
+  const expectRes = checkError(
+    t,
+    INVALID_PARAMS,
+    'missing value for required argument 0'
+  )
+
+  baseRequest(t, server, req, 200, expectRes)
+})


### PR DESCRIPTION
I re-created from #122

# Why this PR is needed

By JSON-RPC 2.0 Specification, params member may be omitted.

But I send below request, application is crushed.

```sh
% curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion", "id": 1}' http://localhost:8545
```