### PR TITLE
Updated ethereumjs-devp2p dependency to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ethereumjs-block": "^2.2.2",
     "ethereumjs-blockchain": "^3.4.0",
     "ethereumjs-common": "^1.5.1",
-    "ethereumjs-devp2p": "^2.5.1",
+    "ethereumjs-devp2p": "^3.0.1",
     "ethereumjs-util": "^7.0.2",
     "fs-extra": "^7.0.1",
     "jayson": "^2.0.6",


### PR DESCRIPTION
I've now working with `v3` of the devp2p library for 1-2 weeks now and I am now confident enough to say that #118 is not an issue. So I think we can safely bump the version here.

That is not to say that connections are always reliable, but that's not a dedicated `v3` problem but generally something to slowly improve upon.