### PR TITLE
Improve sync reliability

### DIFF
--- a/lib/net/peerpool.js
+++ b/lib/net/peerpool.js
@@ -63,6 +63,7 @@ class PeerPool extends EventEmitter {
       server.on('disconnected', (peer) => { this.disconnected(peer) })
     })
     this.opened = true
+    setInterval(this._logPeerStatistics.bind(this), 20000)
   }
 
   /**
@@ -183,6 +184,15 @@ class PeerPool extends EventEmitter {
       if (this.pool.delete(peer.id)) {
         this.emit('removed', peer)
       }
+    }
+  }
+
+  /**
+   * Log peer statistics on a repeated interval
+   */
+  _logPeerStatistics () {
+    if (this.size === 0) {
+      this.logger.info('Looking for suited peers...')
     }
   }
 }

--- a/lib/net/peerpool.js
+++ b/lib/net/peerpool.js
@@ -64,7 +64,7 @@ class PeerPool extends EventEmitter {
       server.on('disconnected', (peer) => { this.disconnected(peer) })
     })
     this.opened = true
-    setInterval(await this._statusCheck.bind(this), 20000)
+    this.statusCheckInterval = setInterval(await this._statusCheck.bind(this), 20000)
   }
 
   /**
@@ -74,6 +74,7 @@ class PeerPool extends EventEmitter {
   async close () {
     this.pool.clear()
     this.opened = false
+    clearInterval(this.statusCheckInterval)
   }
 
   /**

--- a/lib/net/peerpool.js
+++ b/lib/net/peerpool.js
@@ -196,12 +196,13 @@ class PeerPool extends EventEmitter {
     if (this.size === 0) {
       this.noPeerPeriods += 1
       if (this.noPeerPeriods >= 3) {
-        this.servers.map(async server => {
+        const promises = this.servers.map(async server => {
           if (server.bootstrap) {
             this.logger.info('Retriggering bootstrap.')
             await server.bootstrap()
           }
         })
+        await Promise.all(promises)
         this.noPeerPeriods = 0
       } else {
         this.logger.info('Looking for suited peers...')

--- a/lib/net/peerpool.js
+++ b/lib/net/peerpool.js
@@ -43,6 +43,7 @@ class PeerPool extends EventEmitter {
     this.logger = options.logger
     this.maxPeers = options.maxPeers
     this.pool = new Map()
+    this.noPeerPeriods = 0
     this.init()
   }
 
@@ -63,7 +64,7 @@ class PeerPool extends EventEmitter {
       server.on('disconnected', (peer) => { this.disconnected(peer) })
     })
     this.opened = true
-    setInterval(this._logPeerStatistics.bind(this), 20000)
+    setInterval(await this._statusCheck.bind(this), 20000)
   }
 
   /**
@@ -188,11 +189,24 @@ class PeerPool extends EventEmitter {
   }
 
   /**
-   * Log peer statistics on a repeated interval
+   * Peer pool status check on a repeated interval
    */
-  _logPeerStatistics () {
+  async _statusCheck () {
     if (this.size === 0) {
-      this.logger.info('Looking for suited peers...')
+      this.noPeerPeriods += 1
+      if (this.noPeerPeriods >= 3) {
+        this.servers.map(async server => {
+          if (server.bootstrap) {
+            this.logger.info('Retriggering bootstrap.')
+            await server.bootstrap()
+          }
+        })
+        this.noPeerPeriods = 0
+      } else {
+        this.logger.info('Looking for suited peers...')
+      }
+    } else {
+      this.noPeerPeriods = 0
     }
   }
 }

--- a/lib/net/peerpool.js
+++ b/lib/net/peerpool.js
@@ -64,7 +64,7 @@ class PeerPool extends EventEmitter {
       server.on('disconnected', (peer) => { this.disconnected(peer) })
     })
     this.opened = true
-    this.statusCheckInterval = setInterval(await this._statusCheck.bind(this), 20000)
+    this._statusCheckInterval = setInterval(await this._statusCheck.bind(this), 20000)
   }
 
   /**
@@ -74,7 +74,7 @@ class PeerPool extends EventEmitter {
   async close () {
     this.pool.clear()
     this.opened = false
-    clearInterval(this.statusCheckInterval)
+    clearInterval(this._statusCheckInterval)
   }
 
   /**

--- a/lib/net/protocol/ethprotocol.js
+++ b/lib/net/protocol/ethprotocol.js
@@ -46,7 +46,7 @@ class EthProtocol extends Protocol {
    * Create eth protocol
    * @param {Object}   options constructor parameters
    * @param {Chain}    options.chain blockchain
-   * @param {number}   [options.timeout=5000] handshake timeout in ms
+   * @param {number}   [options.timeout=8000] handshake timeout in ms
    * @param {Logger}   [options.logger] logger instance
    */
   constructor (options) {

--- a/lib/net/protocol/lesprotocol.js
+++ b/lib/net/protocol/lesprotocol.js
@@ -65,7 +65,7 @@ class LesProtocol extends Protocol {
    * @param {Chain}       options.chain blockchain
    * @param {FlowControl} [options.flow] flow control manager. if undefined,
    * header serving will be disabled
-   * @param {number}      [options.timeout=5000] handshake timeout in ms
+   * @param {number}      [options.timeout=8000] handshake timeout in ms
    * @param {Logger}      [options.logger] logger instance
    */
   constructor (options) {

--- a/lib/net/protocol/protocol.js
+++ b/lib/net/protocol/protocol.js
@@ -6,7 +6,7 @@ const { defaultLogger } = require('../../logging')
 
 const defaultOptions = {
   logger: defaultLogger,
-  timeout: 5000
+  timeout: 8000
 }
 
 /**
@@ -28,7 +28,7 @@ class Protocol extends EventEmitter {
   /**
    * Create new protocol
    * @param {Object}   options constructor parameters
-   * @param {number}   [options.timeout=5000] handshake timeout in ms
+   * @param {number}   [options.timeout=8000] handshake timeout in ms
    * @param {Logger}   [options.logger] logger instance
    */
   constructor (options) {

--- a/lib/net/server/rlpxserver.js
+++ b/lib/net/server/rlpxserver.js
@@ -101,7 +101,7 @@ class RlpxServer extends Server {
    * @return {Promise}
    */
   async bootstrap () {
-    this.bootnodes.map(node => {
+    const promises = this.bootnodes.map(node => {
       const bootnode = {
         address: node.ip,
         udpPort: node.port,
@@ -109,6 +109,7 @@ class RlpxServer extends Server {
       }
       return this.dpt.bootstrap(bootnode).catch(e => this.error(e))
     })
+    await Promise.all(promises)
   }
 
   /**

--- a/lib/net/server/rlpxserver.js
+++ b/lib/net/server/rlpxserver.js
@@ -91,6 +91,16 @@ class RlpxServer extends Server {
     this.initDpt()
     this.initRlpx()
 
+    await this.bootstrap()
+
+    this.started = true
+  }
+
+  /**
+   * Bootstrap bootnode peers from the network
+   * @return {Promise}
+   */
+  async bootstrap () {
     this.bootnodes.map(node => {
       const bootnode = {
         address: node.ip,
@@ -99,8 +109,6 @@ class RlpxServer extends Server {
       }
       return this.dpt.bootstrap(bootnode).catch(e => this.error(e))
     })
-
-    this.started = true
   }
 
   /**

--- a/lib/service/ethereumservice.js
+++ b/lib/service/ethereumservice.js
@@ -9,7 +9,7 @@ const defaultOptions = {
   lightserv: false,
   common: new Common('mainnet', 'chainstart'),
   minPeers: 3,
-  timeout: 5000,
+  timeout: 8000,
   interval: 1000
 }
 

--- a/lib/service/service.js
+++ b/lib/service/service.js
@@ -109,10 +109,13 @@ class Service extends EventEmitter {
   }
 
   /**
-   * Start service
+   * Stop service
    * @return {Promise}
    */
   async stop () {
+    if (this.opened) {
+      await this.close()
+    }
     this.running = false
     this.logger.info(`Stopped ${this.name} service.`)
   }

--- a/lib/sync/fetcher/fetcher.js
+++ b/lib/sync/fetcher/fetcher.js
@@ -8,7 +8,7 @@ const { defaultLogger } = require('../../logging')
 const defaultOptions = {
   common: new Common('mainnet', 'chainstart'),
   logger: defaultLogger,
-  timeout: 5000,
+  timeout: 8000,
   interval: 1000,
   banTime: 60000,
   maxQueue: 16,

--- a/test/blockchain/chain.js
+++ b/test/blockchain/chain.js
@@ -43,7 +43,7 @@ tape('[Chain]', t => {
     t.equal(chain.genesis.hash.toString('hex'),
       chain.blocks.latest.hash().toString('hex'),
       'get chain.block.latest')
-    chain.close()
+    await chain.close()
     t.end()
   })
 
@@ -80,6 +80,7 @@ tape('[Chain]', t => {
     await chain.getTd(block.hash())
     t.ok(chain.opened, 'chain should open if getTd() called')
     t.equal(await chain.open(), false, 'skip open if already opened')
+    await chain.close()
     t.end()
   })
 
@@ -89,6 +90,7 @@ tape('[Chain]', t => {
     t.notOk(await chain.putBlocks(), 'add undefined block')
     t.notOk(await chain.putBlocks(null), 'add null block')
     t.notOk(await chain.putBlocks([]), 'add empty block list')
+    await chain.close()
     t.end()
   })
 
@@ -98,6 +100,7 @@ tape('[Chain]', t => {
     t.notOk(await chain.putHeaders(), 'add undefined header')
     t.notOk(await chain.putHeaders(null), 'add null header')
     t.notOk(await chain.putHeaders([]), 'add empty header list')
+    await chain.close()
     t.end()
   })
 
@@ -112,7 +115,7 @@ tape('[Chain]', t => {
     await chain.putBlocks([block])
     t.equal(chain.blocks.td.toString(16), '4abcdffff', 'get chain.td')
     t.equal(chain.blocks.height.toString(10), '1', 'get chain.height')
-    chain.close()
+    await chain.close()
     t.end()
   })
 })

--- a/test/integration/peerpool.js
+++ b/test/integration/peerpool.js
@@ -18,6 +18,7 @@ tape('[Integration:PeerPool]', async (t) => {
 
   async function destroy (server, pool) {
     await server.stop()
+    await pool.close()
   }
 
   t.test('should open', async (t) => {

--- a/test/service/fastethereumservice.js
+++ b/test/service/fastethereumservice.js
@@ -57,6 +57,7 @@ tape('[FastEthereumService]', t => {
     service.pool.emit('added', 'peer0')
     service.pool.emit('removed', 'peer0')
     service.pool.emit('error', 'error1')
+    await service.close()
   })
 
   t.test('should start/stop', async (t) => {
@@ -69,6 +70,7 @@ tape('[FastEthereumService]', t => {
     td.verify(service.synchronizer.stop())
     td.verify(server.start())
     t.notOk(await service.stop(), 'already stopped')
+    await server.stop()
     t.end()
   })
 


### PR DESCRIPTION
This PR improves sync reliability by increasing the timeout for jobs in the `Fetcher` class from 5000 to 8000. 

With the existing timeout peers where directly banned again - especially during startup and first initialization period, see:

```shell
INFO [06-11|17:27:36] Listener up transport=libp2p url=/p2p-circuit/ip4/127.0.0.1/tcp/50580/ws/ipfs/QmSjHzTiYBcBwjuYnWEuT4vTvWznsTKTQPjAC4tPBEXF1T
INFO [06-11|17:27:36] Listener up transport=libp2p url=/ip4/127.0.0.1/tcp/50580/ws/ipfs/QmSjHzTiYBcBwjuYnWEuT4vTvWznsTKTQPjAC4tPBEXF1T
INFO [06-11|17:27:36] Started eth service.
INFO [06-11|17:27:36] 0 peers connected (max: 25)
DEBUG [06-11|17:27:37] Peer connected: id=a24ac7c5 address=52.169.42.101:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:37] Found fast peer: id=a24ac7c5 address=52.169.42.101:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:37] Peer added: id=a24ac7c5 address=52.169.42.101:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:37] Peer connected: id=b6b28890 address=159.89.28.211:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:37] Found fast peer: id=b6b28890 address=159.89.28.211:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:37] Peer added: id=b6b28890 address=159.89.28.211:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:38] Peer connected: id=343149e4 address=52.3.158.184:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:38] Found fast peer: id=343149e4 address=52.3.158.184:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:38] Peer added: id=343149e4 address=52.3.158.184:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:38] New height: number=6648919 hash=f49c550d...
DEBUG [06-11|17:27:38] New height: number=6648919 hash=f49c550d...
Connections refilled.
INFO [06-11|17:27:41] 3 peers connected (max: 25)
ERROR [06-11|17:27:42] Error: Request timed out after 5000ms
    at Timeout._onTimeout (/ethereumjs-client/lib/net/protocol/boundprotocol.js:129:16)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
DEBUG [06-11|17:27:46] Syncing with peer: id=343149e4feefa15d882d9fe4ac7d88f885bd05ebb735e547f12e12080a9fa07c8014ca6fd7f373123488102fe5e34111f8509cf0b7de3f5b44339c9f25e87cb8 address=52.3.158.184:30303 transport=rlpx protocols=eth height=6648919
INFO [06-11|17:27:46] 3 peers connected (max: 25)
INFO [06-11|17:27:49] Imported blocks count=128 number=7937 hash=30665f5e... peers=3
Connections refilled.
DEBUG [06-11|17:27:51] Peer removed: id=343149e4 address=52.3.158.184:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:51] Peer banned: id=343149e4 address=52.3.158.184:30303 transport=rlpx protocols=eth
ERROR [06-11|17:27:51] Error: Request timed out after 5000ms
    at Timeout._onTimeout (/ethereumjs-client/lib/net/protocol/boundprotocol.js:129:16)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
DEBUG [06-11|17:27:51] Peer removed: id=a24ac7c5 address=52.169.42.101:30303 transport=rlpx protocols=eth
DEBUG [06-11|17:27:51] Peer banned: id=a24ac7c5 address=52.169.42.101:30303 transport=rlpx protocols=eth
ERROR [06-11|17:27:51] Error: Request timed out after 5000ms
    at Timeout._onTimeout (/ethereumjs-client/lib/net/protocol/boundprotocol.js:129:16)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
```

This led to banning of especially valuable bootstrap peers which made initial connection start often difficult respectively unsuccessful.

This effect is in particular noticeable on a `rinkeby` connection (`--network rinkeby`) which generally is the most suited network atm for a reliable connection.

If generally no suited peers are found on a network, this change won't help on the situation either.

I also added a simple repeated logger with a "Looking for suited peers..." message. This is psychologically helpful as some feedback loop when getting an initial connection is difficult and takes some time (often occuring on `mainnet` e.g.). This gives therefore a "Something is happening..." notion and gives a clear feedback (every 20 seconds) that the client has not crashed or stopped working.

This helps a lot to "bridge" the first 1-2 minutes, if it takes that long until a connection succeeds.