### PR TITLE
Add network id parameter

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,7 +25,7 @@ const args = require('yargs')
     'network-id': {
       describe: `Network ID`,
       choices: networks.map(n => parseInt(n[0])),
-      default: false
+      default: undefined
     },
     'syncmode': {
       describe: 'Blockchain sync mode',

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,11 @@ const args = require('yargs')
       choices: networks.map(n => n[1]),
       default: networks[0][1]
     },
+    'network-id': {
+      describe: `Network ID`,
+      choices: networks.map(n => parseInt(n[0])),
+      default: false
+    },
     'syncmode': {
       describe: 'Blockchain sync mode',
       choices: [ 'light', 'fast' ],
@@ -112,6 +117,13 @@ function runRpcServer (node, options) {
 
 async function run () {
   const syncDirName = args.syncmode === 'light' ? 'lightchaindata' : 'chaindata'
+  // give network id precedence over network name
+  if (args.networkId) {
+    const network = networks.find(n => n[0] === `${args.networkId}`)
+    if (network) {
+      args.network = network[1]
+    }
+  }
   const networkDirName = args.network === 'mainnet' ? '' : `${args.network}/`
   const chainParams = args.params ? await parse.params(args.params) : args.network
   // Initialize Common with an explicit 'chainstart' HF set until

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ethereumjs-account": "^3.0.0",
     "ethereumjs-block": "^2.2.2",
     "ethereumjs-blockchain": "^3.4.0",
-    "ethereumjs-common": "^1.5.1",
+    "ethereumjs-common": "^1.5.2",
     "ethereumjs-devp2p": "^3.0.1",
     "ethereumjs-util": "^7.0.2",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
Hive uses a network id parameter to configure clients.
This PR adds support for `network-id` and overwrites / has precedence over `network`.