### PR TITLE
Fix getBlockByHash tsc error

### DIFF
--- a/lib/rpc/modules/eth.ts
+++ b/lib/rpc/modules/eth.ts
@@ -82,7 +82,7 @@ export class Eth {
    * as the second argument
    * @return {Promise}
    */
-  async getBlockByHash (params: [string, number], cb: (err: Error | null, val?: any) => void) {
+  async getBlockByHash (params: [string, boolean], cb: (err: Error | null, val?: any) => void) {
     let [blockHash, includeTransactions] = params
 
     try {

--- a/lib/rpc/modules/eth.ts
+++ b/lib/rpc/modules/eth.ts
@@ -82,7 +82,7 @@ export class Eth {
    * as the second argument
    * @return {Promise}
    */
-  async getBlockByHash (params: string[] | boolean[], cb: (err: Error | null, val?: any) => void) {
+  async getBlockByHash (params: [string, number], cb: (err: Error | null, val?: any) => void) {
     let [blockHash, includeTransactions] = params
 
     try {


### PR DESCRIPTION
Tiny fix to get tests and coverage running as a baseline for new PRs (#151, #152, #153) coming in....

The most recent `ethereumjs-util` update had stricter types and [latest builds here][1] were failing with:
```
Type 'false' is not assignable to type 'string | number | number[] | Buffer | BN | Uint8Array | TransformableToArray | TransformableToBuffer | null | undefined'.

89       let block = await this._chain.getBlock(toBuffer(blockHash))
                                                         ~~~~~~~~~
```

Proposed change corrects the types so they match the docs description of the `params` arg:
```
An array of two parameters: A block hash as the first argument and a boolean determining 
whether it returns full transaction objects or just the transaction hashes
```

(This project .gitignore's package-lock.json)  

[1]: https://github.com/ethereumjs/ethereumjs-client/actions/runs/317269957 