### PR TITLE
Upgrade @ethereumjs/config-coverage and nyc

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,5 @@
 {
-  "extends": "@ethereumjs/config-nyc",
+  "extends": "@ethereumjs/config-coverage",
   "include": [
     "lib/**/*.ts"
   ]

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-spread": "^7.10.1",
-    "@ethereumjs/config-nyc": "^1.1.1",
+    "@ethereumjs/config-coverage": "^2.0.0",
     "@ethereumjs/config-tsc": "^1.1.0",
     "@polkadot/ts": "^0.3.48",
     "@types/node": "^14.11.5",
@@ -101,7 +101,7 @@
     "karma-firefox-launcher": "^1.3.0",
     "karma-tap": "^4.2.0",
     "karma-typescript": "^5.0.3",
-    "nyc": "~13.3.0",
+    "nyc": "^14.1.1",
     "pino": "^5.8.0",
     "pino-pretty": "^2.2.2",
     "standard": "~12.0.1",


### PR DESCRIPTION
#148 

Bumps
+ @ethereumjs/config-nyc v1.1.1 -> @ethereumjs/config-coverage v2.0.0
+ nyc ~13.3.0 -> ^14.1.1 (similar version used in monorepo's [block package][1])

The coverage script commands here are like those used in the [vm package][2]. Both projects have split their test suites into subcommands which need to be run back to back when measuring coverage.

[1]: https://github.com/ethereumjs/ethereumjs-vm/blob/d5560d86ea22f149837229c79778a17f44b80c76/packages/block/package.json#L64
[2]: https://github.com/ethereumjs/ethereumjs-vm/blob/d5560d86ea22f149837229c79778a17f44b80c76/packages/vm/package.json#L15-L16





