### PR TITLE
Upgrade to @ethereumjs/config-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "devDependencies": {
     "@babel/plugin-transform-spread": "^7.10.1",
     "@ethereumjs/config-nyc": "^1.1.1",
-    "@ethereumjs/config-tsc": "^1.1.0",
+    "@ethereumjs/config-typescript": "^2.0.0",
     "@polkadot/ts": "^0.3.48",
     "@types/node": "^14.11.5",
     "@types/tape": "^4.13.0",

--- a/test/blockchain/chain.spec.ts
+++ b/test/blockchain/chain.spec.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 const Block = require('ethereumjs-block')
 const { toBuffer } = require('ethereumjs-util')
 const { Chain } = require('../../lib/blockchain')

--- a/test/integration/fastethereumservice.ts
+++ b/test/integration/fastethereumservice.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import { FastEthereumService } from '../../lib/service'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'

--- a/test/integration/fastsync.ts
+++ b/test/integration/fastsync.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import { FastEthereumService } from '../../lib/service'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'

--- a/test/integration/lightethereumservice.ts
+++ b/test/integration/lightethereumservice.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import { LightEthereumService } from '../../lib/service'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'

--- a/test/integration/lightsync.ts
+++ b/test/integration/lightsync.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import { FastEthereumService, LightEthereumService } from '../../lib/service'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'

--- a/test/integration/node.ts
+++ b/test/integration/node.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import Node from '../../lib/node'
 import MockServer from './mocks/mockserver'
 import { defaultLogger } from '../../lib/logging'

--- a/test/integration/peerpool.ts
+++ b/test/integration/peerpool.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 import { EthProtocol } from '../../lib/net/protocol'
 import { PeerPool } from '../../lib/net/peerpool'
 import MockServer from './mocks/mockserver'

--- a/test/logging.ts
+++ b/test/logging.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 const { getLogger } = require('../lib/logging')
 
 tape('[Logging]', t => {

--- a/test/net/peer/libp2pnode.ts
+++ b/test/net/peer/libp2pnode.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 // const Libp2pNode = require('../../../lib/net/peer/libp2pnode')
 

--- a/test/net/peer/peer.ts
+++ b/test/net/peer/peer.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { Peer } from '../../../lib/net/peer'
 import * as events from 'events'

--- a/test/net/peer/rlpxpeer.ts
+++ b/test/net/peer/rlpxpeer.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { RlpxPeer } from '../../../lib/net/peer/rlpxpeer'
@@ -23,7 +23,7 @@ tape.skip('[RlpxPeer]', t => {
   })
 
   // TODO: disabled for typescript transition. Test case not reproduceable with
-  // necessary Protocol instantiations due to protocol type addition to RlpxPeer.capabilities() 
+  // necessary Protocol instantiations due to protocol type addition to RlpxPeer.capabilities()
   /*t.test('should compute capabilities', t => {
     const protocols = [ { name: 'eth', versions: [62, 63] }, { name: 'les', versions: [2] } ]
     const caps = RlpxPeer.capabilities(protocols).map(

--- a/test/net/peerpool.ts
+++ b/test/net/peerpool.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { defaultLogger } from '../../lib/logging'

--- a/test/net/protocol/boundprotocol.ts
+++ b/test/net/protocol/boundprotocol.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { Sender } from '../../../lib/net/protocol/sender'

--- a/test/net/protocol/ethprotocol.ts
+++ b/test/net/protocol/ethprotocol.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 import { Chain } from '../../../lib/blockchain/chain'
 const { EthProtocol } = require('../../../lib/net/protocol')
 

--- a/test/net/protocol/flowcontrol.ts
+++ b/test/net/protocol/flowcontrol.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const timers = require('testdouble-timers').default
 const { FlowControl } = require('../../../lib/net/protocol')

--- a/test/net/protocol/lesprotocol.ts
+++ b/test/net/protocol/lesprotocol.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 import { Chain } from '../../../lib/blockchain'
 const { LesProtocol } = require('../../../lib/net/protocol')
 const BN = require('bn.js')

--- a/test/net/protocol/libp2psender.ts
+++ b/test/net/protocol/libp2psender.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const pull = require('pull-stream')
 const DuplexPair = require('pull-pair/duplex')
 const { Libp2pSender } = require('../../../lib/net/protocol')

--- a/test/net/protocol/protocol.ts
+++ b/test/net/protocol/protocol.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { Sender } from '../../../lib/net/protocol/sender'

--- a/test/net/protocol/rlpxsender.ts
+++ b/test/net/protocol/rlpxsender.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const { RlpxSender } = require('../../../lib/net/protocol')
 const EventEmitter = require('events')

--- a/test/net/protocol/sender.ts
+++ b/test/net/protocol/sender.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const { Sender } = require('../../../lib/net/protocol')
 
 tape('[Sender]', t => {

--- a/test/net/server/libp2pserver.ts
+++ b/test/net/server/libp2pserver.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 // const EventEmitter = require('events')
 const { defaultLogger } = require('../../../lib/logging')

--- a/test/net/server/rlpxserver.ts
+++ b/test/net/server/rlpxserver.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const EventEmitter = require('events')
 import { RlpxServer } from '../../../lib/net/server/rlpxserver'

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const EventEmitter = require('events')
 const { defaultLogger } = require('../lib/logging')

--- a/test/rpc/eth/getBlockByHash.ts
+++ b/test/rpc/eth/getBlockByHash.ts
@@ -1,11 +1,11 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { baseSetup, params, baseRequest } from '../helpers'
 import { checkError } from '../util'
 
 const method = 'eth_getBlockByHash'
 
-test(`${method}: call with valid arguments`, t => {
+tape(`${method}: call with valid arguments`, t => {
   const server = baseSetup()
 
   const req = params(method, [
@@ -19,7 +19,7 @@ test(`${method}: call with valid arguments`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with false for second argument`, t => {
+tape(`${method}: call with false for second argument`, t => {
   const server = baseSetup()
 
   const req = params(method, [
@@ -35,7 +35,7 @@ test(`${method}: call with false for second argument`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid block hash without 0x`, t => {
+tape(`${method}: call with invalid block hash without 0x`, t => {
   const server = baseSetup()
 
   const req = params(method, ['WRONG BLOCK NUMBER', true])
@@ -47,7 +47,7 @@ test(`${method}: call with invalid block hash without 0x`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid hex string as block hash`, t => {
+tape(`${method}: call with invalid hex string as block hash`, t => {
   const server = baseSetup()
 
   const req = params(method, ['0xWRONG BLOCK NUMBER', true])
@@ -59,7 +59,7 @@ test(`${method}: call with invalid hex string as block hash`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockByHash without second parameter', t => {
+tape('call eth_getBlockByHash without second parameter', t => {
   const server = baseSetup()
 
   const req = params(method, ['0x0'])
@@ -71,7 +71,7 @@ test('call eth_getBlockByHash without second parameter', t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test('call eth_getBlockByHash with invalid second parameter', t => {
+tape('call eth_getBlockByHash with invalid second parameter', t => {
   const server = baseSetup()
 
   const req = params(method, ['0x0', 'INVALID PARAMETER'])

--- a/test/rpc/eth/getBlockByNumber.ts
+++ b/test/rpc/eth/getBlockByNumber.ts
@@ -1,4 +1,4 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { startRPC, createManager, createNode, params, baseRequest } from '../helpers'
 import { checkError } from '../util'
@@ -19,7 +19,7 @@ function createBlockchain () {
 
 const method = 'eth_getBlockByNumber'
 
-test(`${method}: call with valid arguments`, t => {
+tape(`${method}: call with valid arguments`, t => {
   const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
@@ -35,7 +35,7 @@ test(`${method}: call with valid arguments`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with false for second argument`, t => {
+tape(`${method}: call with false for second argument`, t => {
   const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
@@ -57,7 +57,7 @@ test(`${method}: call with false for second argument`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid block number`, t => {
+tape(`${method}: call with invalid block number`, t => {
   const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
@@ -70,7 +70,7 @@ test(`${method}: call with invalid block number`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call without second parameter`, t => {
+tape(`${method}: call without second parameter`, t => {
   const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 
@@ -83,7 +83,7 @@ test(`${method}: call without second parameter`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid second parameter`, t => {
+tape(`${method}: call with invalid second parameter`, t => {
   const manager = createManager(createNode({ blockchain: createBlockchain() }))
   const server = startRPC(manager.getMethods())
 

--- a/test/rpc/eth/getBlockNumber.ts
+++ b/test/rpc/eth/getBlockNumber.ts
@@ -1,10 +1,10 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { toBuffer, intToHex } from 'ethereumjs-util'
 import { startRPC, createManager, createNode, params, baseRequest } from '../helpers'
 
 const method = 'eth_blockNumber'
 
-test(`${method}: call with valid arguments`, t => {
+tape(`${method}: call with valid arguments`, t => {
   const mockBlockNumber = 123
   const mockBlockChain = {
     getLatestHeader: () => {

--- a/test/rpc/eth/getBlockTransactionCountByHash.ts
+++ b/test/rpc/eth/getBlockTransactionCountByHash.ts
@@ -1,11 +1,11 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { baseSetup, params, baseRequest } from '../helpers'
 import { checkError } from '../util'
 
 const method = 'eth_getBlockTransactionCountByHash'
 
-test(`${method}: call with valid arguments`, t => {
+tape(`${method}: call with valid arguments`, t => {
   const server = baseSetup()
 
   const req = params(method, [
@@ -22,7 +22,7 @@ test(`${method}: call with valid arguments`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid block hash without 0x`, t => {
+tape(`${method}: call with invalid block hash without 0x`, t => {
   const server = baseSetup()
 
   const req = params(method, ['WRONG BLOCK NUMBER'])
@@ -34,7 +34,7 @@ test(`${method}: call with invalid block hash without 0x`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid hex string as block hash`, t => {
+tape(`${method}: call with invalid hex string as block hash`, t => {
   const server = baseSetup()
 
   const req = params(method, ['0xWRONG BLOCK NUMBER', true])
@@ -46,7 +46,7 @@ test(`${method}: call with invalid hex string as block hash`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call without first parameter`, t => {
+tape(`${method}: call without first parameter`, t => {
   const server = baseSetup()
 
   const req = params(method, [])
@@ -58,7 +58,7 @@ test(`${method}: call without first parameter`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with invalid second parameter`, t => {
+tape(`${method}: call with invalid second parameter`, t => {
   const server = baseSetup()
 
   const req = params(method, ['INVALID PARAMETER'])

--- a/test/rpc/eth/protocolVersion.ts
+++ b/test/rpc/eth/protocolVersion.ts
@@ -1,9 +1,9 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { baseSetup, params, baseRequest } from '../helpers'
 
 const method = 'eth_protocolVersion'
 
-test(`${method}: call`, t => {
+tape(`${method}: call`, t => {
   const server = baseSetup()
 
   const req = params(method, [])

--- a/test/rpc/helpers.ts
+++ b/test/rpc/helpers.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 const jayson = require('jayson')
 const request = require('supertest')
 import Common from 'ethereumjs-common'

--- a/test/rpc/net/listening.ts
+++ b/test/rpc/net/listening.ts
@@ -1,9 +1,9 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { startRPC, createManager, createNode, params, baseRequest } from '../helpers'
 
 const method = 'net_listening'
 
-test(`${method}: call while listening`, t => {
+tape(`${method}: call while listening`, t => {
   const manager = createManager(createNode({ opened: true }))
   const server = startRPC(manager.getMethods())
 
@@ -27,7 +27,7 @@ test(`${method}: call while listening`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call while not listening`, t => {
+tape(`${method}: call while not listening`, t => {
   const manager = createManager(createNode({ opened: false }))
   const server = startRPC(manager.getMethods())
 

--- a/test/rpc/net/peerCount.ts
+++ b/test/rpc/net/peerCount.ts
@@ -1,9 +1,9 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { startRPC, createManager, createNode, params, baseRequest } from '../helpers'
 
 const method = 'net_peerCount'
 
-test(`${method}: call`, t => {
+tape(`${method}: call`, t => {
   const manager = createManager(createNode({ opened: true }))
   const server = startRPC(manager.getMethods())
 

--- a/test/rpc/net/version.ts
+++ b/test/rpc/net/version.ts
@@ -1,4 +1,4 @@
-import * as test from 'tape'
+import tape from 'tape'
 import Common from 'ethereumjs-common'
 import { startRPC, createManager, createNode, baseSetup, params, baseRequest } from '../helpers'
 
@@ -27,7 +27,7 @@ function compareResult (t: any, result: any, chainId: any) {
   }
 }
 
-test(`${method}: call on ropsten`, t => {
+tape(`${method}: call on ropsten`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('ropsten') }))
   const server = startRPC(manager.getMethods())
 
@@ -39,7 +39,7 @@ test(`${method}: call on ropsten`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call on mainnet`, t => {
+tape(`${method}: call on mainnet`, t => {
   const server = baseSetup()
 
   const req = params(method, [])
@@ -50,7 +50,7 @@ test(`${method}: call on mainnet`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call on rinkeby`, t => {
+tape(`${method}: call on rinkeby`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('rinkeby') }))
   const server = startRPC(manager.getMethods())
 
@@ -62,7 +62,7 @@ test(`${method}: call on rinkeby`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call on kovan`, t => {
+tape(`${method}: call on kovan`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('kovan') }))
   const server = startRPC(manager.getMethods())
 
@@ -74,7 +74,7 @@ test(`${method}: call on kovan`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call on goerli`, t => {
+tape(`${method}: call on goerli`, t => {
   const manager = createManager(createNode({ opened: true, commonChain: new Common('goerli') }))
   const server = startRPC(manager.getMethods())
 

--- a/test/rpc/rpc.ts
+++ b/test/rpc/rpc.ts
@@ -1,9 +1,9 @@
-import * as test from 'tape'
+import tape from 'tape'
 const request = require('supertest')
 import { startRPC, closeRPC } from './helpers'
 import { METHOD_NOT_FOUND } from '../../lib/rpc/error-code'
 
-test('call JSON-RPC without Content-Type header', t => {
+tape('call JSON-RPC without Content-Type header', t => {
   const server = startRPC({})
 
   const req = 'plaintext'
@@ -18,7 +18,7 @@ test('call JSON-RPC without Content-Type header', t => {
     })
 })
 
-test('call JSON RPC with non-exist method', t => {
+tape('call JSON RPC with non-exist method', t => {
   const server = startRPC({})
   const req = {
     jsonrpc: '2.0',

--- a/test/rpc/util.ts
+++ b/test/rpc/util.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape'
+import tape from 'tape'
 
 export function checkError (t: tape.Test, expectedCode: any, expectedMessage?: any) {
   return (res: any) => {

--- a/test/rpc/validation.ts
+++ b/test/rpc/validation.ts
@@ -1,4 +1,4 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { startRPC } from './helpers'
 import { middleware } from '../../lib/rpc/validation'
 import { baseRequest } from './helpers'
@@ -7,7 +7,7 @@ import { INVALID_PARAMS } from '../../lib/rpc/error-code'
 
 const prefix = 'rpc/validation:'
 
-test(`${prefix} should work without \`params\` when it's optional`, t => {
+tape(`${prefix} should work without \`params\` when it's optional`, t => {
   const mockMethodName = 'mock'
   const server = startRPC({
     [mockMethodName]: middleware((params: any, cb: any) => {
@@ -26,7 +26,7 @@ test(`${prefix} should work without \`params\` when it's optional`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${prefix} should return error without \`params\` when it's required`, t => {
+tape(`${prefix} should return error without \`params\` when it's required`, t => {
   const mockMethodName = 'mock'
   const server = startRPC({
     [mockMethodName]: middleware((params: any, cb: any) => {

--- a/test/rpc/web3/clientVersion.ts
+++ b/test/rpc/web3/clientVersion.ts
@@ -1,10 +1,10 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { platform } from 'os'
 import { baseSetup, params, baseRequest } from '../helpers'
 
 const method = 'web3_clientVersion'
 
-test(`${method}: call`, t => {
+tape(`${method}: call`, t => {
   const server = baseSetup()
 
   const req = params(method, [])

--- a/test/rpc/web3/sha3.ts
+++ b/test/rpc/web3/sha3.ts
@@ -1,4 +1,4 @@
-import * as test from 'tape'
+import tape from 'tape'
 import { baseSetup, params, baseRequest } from '../helpers'
 
 const method = 'web3_sha3'
@@ -23,7 +23,7 @@ function compareErrorMsg (t: any, error: any, errorMsg: any) {
   }
 }
 
-test(`${method}: call with one valid parameter`, t => {
+tape(`${method}: call with one valid parameter`, t => {
   const server = baseSetup()
 
   const req = params(method, ['0x68656c6c6f20776f726c64'])
@@ -49,7 +49,7 @@ test(`${method}: call with one valid parameter`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with one non-hex parameter`, t => {
+tape(`${method}: call with one non-hex parameter`, t => {
   const server = baseSetup()
 
   const req = params(method, ['hello world'])
@@ -64,7 +64,7 @@ test(`${method}: call with one non-hex parameter`, t => {
   baseRequest(t, server, req, 200, expectRes)
 })
 
-test(`${method}: call with no parameters`, t => {
+tape(`${method}: call with no parameters`, t => {
   const server = baseSetup()
 
   const req = params(method, [])

--- a/test/service/fastethereumservice.ts
+++ b/test/service/fastethereumservice.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const EventEmitter = require('events')
 import { defaultLogger } from '../../lib/logging'

--- a/test/service/lightethereumservice.ts
+++ b/test/service/lightethereumservice.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 const EventEmitter = require('events')
 import { defaultLogger } from '../../lib/logging'

--- a/test/sync/fastsync.ts
+++ b/test/sync/fastsync.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { BN } from 'ethereumjs-util'
 import { EventEmitter } from 'events'

--- a/test/sync/fetcher/blockfetcher.ts
+++ b/test/sync/fetcher/blockfetcher.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { BN } from 'ethereumjs-util'
 import { EventEmitter } from 'events'

--- a/test/sync/fetcher/fetcher.ts
+++ b/test/sync/fetcher/fetcher.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { defaultLogger } from '../../../lib/logging'
 defaultLogger.silent = true

--- a/test/sync/fetcher/headerfetcher.ts
+++ b/test/sync/fetcher/headerfetcher.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { defaultLogger } from '../../../lib/logging'

--- a/test/sync/lightsync.ts
+++ b/test/sync/lightsync.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { BN } from 'ethereumjs-util'
 import { EventEmitter } from 'events'

--- a/test/sync/sync.ts
+++ b/test/sync/sync.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 const td = require('testdouble')
 import { EventEmitter } from 'events'
 import { defaultLogger } from '../../lib/logging'

--- a/test/util/parse.ts
+++ b/test/util/parse.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape-catch'
+import tape from 'tape-catch'
 import * as path from 'path'
 import { parseBootnodes, parseTransports, parseParams } from '../../lib/util'
 

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,11 +1,11 @@
 {
-  "extends": "./tsconfig.prod.json",
+  "extends": "@ethereumjs/config-typescript/tsconfig.browser.json",
   "include": ["browser/index.js"],
   "exclude": ["lib/index.js"],
   "compilerOptions": {
     "outDir": "dist.browser",
-    "target": "es5",
-    "lib": ["es5"],
-    "alwaysStrict": true
+    "typeRoots": [
+      "node_modules/@polkadot/ts"
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "@ethereumjs/config-tsc",
+  "extends": "@ethereumjs/config-typescript",
   "include": ["bin", "lib", "test"],
   "compilerOptions": {
-    "target": "ES2017",
     "typeRoots": [
       "node_modules/@polkadot/ts"
     ]

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,9 +1,11 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "@ethereumjs/config-typescript/tsconfig.prod.json",
   "include": ["bin", "lib"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "ES2017",
-    "lib": ["es2018", "dom"]
+    "lib": ["es2018", "dom"],
+    "typeRoots": [
+      "node_modules/@polkadot/ts"
+    ]
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const { resolve } = require('path')
 
 module.exports = {
   mode: 'production',
-  entry: './dist.browser/index.js',
+  entry: './dist.browser/browser/index.js',
   module: {
     rules: [
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const { resolve } = require('path')
 
 module.exports = {
   mode: 'production',
-  entry: './dist.browser/browser/index.js',
+  entry: './dist.browser/index.js',
   module: {
     rules: [
       {


### PR DESCRIPTION
#148 

+ Upgrade to @ethereumjs/config-typescript@2.0.0
+ Follows pattern for ts.config files established in [ethereumjs-vm 913][1]
+ Updates `tape` imports as necessary

**Notes**
+ `npm run build` is broken prior to this PR and will require substantial work to get running. The relevant entry points still need to be ported to TS, etc. Have not altered those script commands. (Addressed in #155)
+ Manually verified that the production build works and client launches from cli as expected

[1]: https://github.com/ethereumjs/ethereumjs-vm/pull/913