### PR TITLE
Override implicit dependency lint rule for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,16 @@ module.exports = {
     // Many methods have been sketched in as stubs & their params trigger this.
     // Duplicates the (more tolerant) @typescript-eslint/no-unused-vars
     'no-unused-vars': 'off'
-  }
+  },
+  overrides: [
+    {
+      files: ['test/**/*.ts'],
+      rules: {
+        'implicit-dependencies/no-implicit': [
+          'error',
+          { peer: false, dev: true, optional: false },
+        ],
+      },
+    },
+  ],
 }


### PR DESCRIPTION
Add overrides to eslint rules to fix false-positive checks in tests directory. It allows to require dev-dependencies from `test/` directory.

### Questions

- [ ] This PR probably requires changes in tests to remove eslint-disable comments. But it seems conflict-prone to change whole tests files at once. And it seems logical to fix it continuously. Is `.eslint.js` changes is enough for this?

- [ ] Should it be done organisation-wide in [eslint-config-defaults](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/lint)?