### PR TITLE
Add PNPM and Yarn lockfiles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ build/Release
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
 package-lock.json
+pnpm-lock.yaml
+yarn.lock
 
 # ChainDB folder
 chaindata


### PR DESCRIPTION
To make EthereumJS setup more developer-friendly I've added lockfiles for different package managers into `.gitignore`. I'm using [PNPM](https://pnpm.js.org/) and It took about 30 seconds to install this package on my machine vs ~2 minutes by NPM. 