### PR TITLE
Replace binary directive with canonical form

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/lib/index.d.ts",
   "browser": "dist/bundle.js",
   "bin": {
-    "ethereumjs": "node bin/cli.js"
+    "ethereumjs": "bin/cli.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
According to package.json [specification](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin) binary directive should contain a path to binary and not a command. It leads to error on PNPM and probably other PMs too.