### PR TITLE
Fix missing pull-pair

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "nyc": "^14.1.1",
     "pino": "^5.8.0",
     "pino-pretty": "^2.2.2",
+    "pull-pair": "^1.1.0",
     "supertest": "^3.1.0",
     "tape": "~4.10.1",
     "tape-catch": "~1.0.6",


### PR DESCRIPTION
Tests require [pull-pair](https://www.npmjs.com/package/pull-pair) package: https://github.com/ethereumjs/ethereumjs-client/blob/1305892785b31db06327e5178501cf37a1e24696/test/net/protocol/libp2psender.ts#L5 But it's not presented in list of dependencies and fails to execute libp2psender test.

### Changes
- pull-pair added to `package.json` as a dev dependency.