### PR TITLE
Update winston to v3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "ts-node node_modules/tape/bin/tape 'test/!(integration)/**/*.ts'",
+    "test:unit": "ts-node node_modules/tape/bin/tape 'test/{!(integration)/**/*.ts,logger.ts}'",
     "test:integration": "ts-node node_modules/tape/bin/tape 'test/integration/**/*.ts'",
     "test:browser": "karma start karma.conf.js"
   },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "qheap": "^1.4.0",
     "rlp": "^2.0.0",
     "util-promisify": "^2.1.0",
-    "winston": "^3.1.0",
+    "winston": "3.3.3",
     "yargs": "^13.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is a part of #149 issue to remove/update dependencies. It updates winston to the latest version 3.3.3 available ATM.