### PR TITLE
Add tape script to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "docs:build": "typedoc --tsconfig tsconfig.prod.json",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
+    "tape": "ts-node node_modules/tape/bin/tape",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "ts-node node_modules/tape/bin/tape 'test/!(integration)/**/*.ts'",
-    "test:integration": "ts-node node_modules/tape/bin/tape 'test/integration/**/*.ts'",
+    "test:unit": "npm run tape -- 'test/!(integration)/**/*.ts'",
+    "test:integration": "npm run tape -- 'test/integration/**/*.ts'",
     "test:browser": "karma start karma.conf.js"
   },
   "husky": {


### PR DESCRIPTION
This PR makes test running more atomic and allow to run tests manually like this:

```shell
npm run tape -- test/logger.ts
```

It just makes test running commands set more atomic. It's helpful enhancement for manual test running.
