### PR TITLE
Remove unused ms package from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "libp2p-tcp": "^0.13.0",
     "libp2p-websockets": "^0.12.0",
     "merkle-patricia-tree": "^4.0.0",
-    "ms": "^2.1.1",
     "peer-id": "^0.12.2",
     "peer-info": "^0.15.1",
     "pull-catch": "^1.0.0",


### PR DESCRIPTION
It seems like ms package isn't in use: I couldn't find it in `lib/`, `test/` or `bin/` directories. So I've removed it. All tests pass successfully.

This PR is part of #149 issue.