### PR TITLE
Makes tests compatible with dependency hoisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docs:build": "typedoc --tsconfig tsconfig.prod.json",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "tape": "ts-node node_modules/tape/bin/tape",
+    "tape": "ts-node node_modules/.bin/tape",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "npm run tape -- 'test/!(integration)/**/*.ts'",
     "test:integration": "npm run tape -- 'test/integration/**/*.ts'",


### PR DESCRIPTION
This tiny change helps prepare the project for a monorepo setup.

Npm scripts are located in two places:

1. /node_modules/package/path-to-script/script
1. /node_modules/.bin/script => symlink

The first case wont resolve to a path if the dependencies are hoisted, but the second case will always resolve to the right path.