### PR TITLE
Integrate VM

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -7,7 +7,6 @@ import Node from '../lib/node'
 import { Config } from '../lib/config'
 import { Logger } from '../lib/logging'
 import { RPCManager } from '../lib/rpc'
-const level = require('level')
 const path = require('path')
 const fs = require('fs-extra')
 const chains = require('@ethereumjs/common/dist/chains').chains
@@ -100,7 +99,6 @@ async function runNode(config: Config) {
   }
   const node = new Node({
     config,
-    db: level(syncDataDir),
   })
   node.on('error', (err: any) => config.logger.error(err))
   node.on('listening', (details: any) => {

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -10,6 +10,7 @@ import { RPCManager } from '../lib/rpc'
 const path = require('path')
 const fs = require('fs-extra')
 const chains = require('@ethereumjs/common/dist/chains').chains
+const level = require('level')
 
 const networks = Object.entries(chains.names)
 
@@ -99,6 +100,7 @@ async function runNode(config: Config) {
   }
   const node = new Node({
     config,
+    db: level(syncDataDir),
   })
   node.on('error', (err: any) => config.logger.error(err))
   node.on('listening', (details: any) => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,12 +1,8 @@
 const os = require('os')
 import Common from '@ethereumjs/common'
-import { Chain } from './blockchain'
 import { getLogger, Logger } from './logging'
 import { Libp2pServer, RlpxServer } from './net/server'
 import { parseTransports } from './util'
-import type { LevelUp } from 'levelup'
-import VM from '@ethereumjs/vm'
-const level = require('level')
 
 export interface ConfigOptions {
   /**
@@ -98,11 +94,6 @@ export interface ConfigOptions {
    * Default: `25`
    */
   maxPeers?: number
-
-  /**
-   * The VM to use
-   */
-  vm?: VM
 }
 
 export class Config {
@@ -133,9 +124,6 @@ export class Config {
   public readonly loglevel: string
   public readonly minPeers: number
   public readonly maxPeers: number
-  public readonly blockchain: Chain
-  public readonly db: LevelUp
-  public readonly vm: VM
 
   public readonly servers: (RlpxServer | Libp2pServer)[] = []
 
@@ -152,14 +140,6 @@ export class Config {
     this.loglevel = options.loglevel ?? Config.LOGLEVEL_DEFAULT
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
-    this.db = level(this.getSyncDataDirectory())
-    this.blockchain = new Chain({ config: this, db: this.db })
-    this.vm =
-      options.vm ??
-      new VM({
-        common: this.common,
-        blockchain: this.blockchain.blockchain,
-      })
 
     if (options.logger) {
       if (options.loglevel) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,8 +1,12 @@
 const os = require('os')
 import Common from '@ethereumjs/common'
+import { Chain } from './blockchain'
 import { getLogger, Logger } from './logging'
 import { Libp2pServer, RlpxServer } from './net/server'
 import { parseTransports } from './util'
+import type { LevelUp } from 'levelup'
+import VM from '@ethereumjs/vm'
+const level = require('level')
 
 export interface ConfigOptions {
   /**
@@ -94,6 +98,11 @@ export interface ConfigOptions {
    * Default: `25`
    */
   maxPeers?: number
+
+  /**
+   * The VM to use
+   */
+  vm?: VM
 }
 
 export class Config {
@@ -124,6 +133,9 @@ export class Config {
   public readonly loglevel: string
   public readonly minPeers: number
   public readonly maxPeers: number
+  public readonly blockchain: Chain
+  public readonly db: LevelUp
+  public readonly vm: VM
 
   public readonly servers: (RlpxServer | Libp2pServer)[] = []
 
@@ -140,6 +152,14 @@ export class Config {
     this.loglevel = options.loglevel ?? Config.LOGLEVEL_DEFAULT
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
+    this.db = level(this.getSyncDataDirectory())
+    this.blockchain = new Chain({ config: this, db: this.db })
+    this.vm =
+      options.vm ??
+      new VM({
+        common: this.common,
+        blockchain: this.blockchain.blockchain,
+      })
 
     if (options.logger) {
       if (options.loglevel) {

--- a/lib/service/fullethereumservice.ts
+++ b/lib/service/fullethereumservice.ts
@@ -4,6 +4,7 @@ import { EthProtocol } from '../net/protocol/ethprotocol'
 import { LesProtocol } from '../net/protocol/lesprotocol'
 import { Peer } from '../net/peer/peer'
 import { Protocol, BoundProtocol } from '../net/protocol'
+import VM from '@ethereumjs/vm'
 
 interface FullEthereumServiceOptions extends EthereumServiceOptions {
   /* Serve LES requests (default: false) */
@@ -17,6 +18,7 @@ interface FullEthereumServiceOptions extends EthereumServiceOptions {
 export class FullEthereumService extends EthereumService {
   public synchronizer: FullSynchronizer
   public lightserv: boolean
+  public vm: VM
   /**
    * Create new ETH service
    * @param {FullEthereumServiceOptions}
@@ -27,6 +29,10 @@ export class FullEthereumService extends EthereumService {
     this.lightserv = options.lightserv ?? false
 
     this.config.logger.info('Full sync mode')
+    this.vm = new VM({
+      common: this.config.common,
+      blockchain: this.chain.blockchain,
+    })
     this.synchronizer = new FullSynchronizer({
       config: this.config,
       pool: this.pool,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@ethereumjs/block": "^3.0.0-beta.2",
     "@ethereumjs/blockchain": "^5.0.0-beta.2",
     "@ethereumjs/common": "^2.0.0-beta.2",
+    "@ethereumjs/vm": "^5.0.0-rc.1",
     "chalk": "^2.4.1",
     "ethereumjs-devp2p": "^3.0.3",
     "ethereumjs-util": "^7.0.7",


### PR DESCRIPTION
This PR creates a Chain option in config, so that consumers can use a custom (Block)chain object. 

I am not yet sure if I like this, because Node "unpacks" the config, while each Service (where `Chain` is created) itself has access directly to the config. I wrote it like this because `EthereumServiceOptions` specifically has a `chain` parameter, so this would expect this to get explicitly passed on and not read it from the config.

Closes #186 